### PR TITLE
Fixes: multicloud gitops labels and branch name for IE2.0

### DIFF
--- a/industrial-edge/getting-started.md
+++ b/industrial-edge/getting-started.md
@@ -42,7 +42,7 @@ service](https://console.redhat.com/openshift/create).
 1. Fork the [manuela-dev](https://github.com/hybrid-cloud-patterns/manuela-dev) repo on GitHub.  It is necessary to fork this repo because the GitOps framework will push tags to this repo that match the versions of software that it will deploy.
 1. Fork this repo on GitHub. It is necessary to fork because your fork will be updated as part of the GitOps and DevOps processes.
 
-1. Clone the forked copy of this repo.
+1. Clone the forked copy of this repo. Use branch `stable-2.0`. 
 
    ```sh
    git clone --recurse-submodules git@github.com:your-username/industrial-edge.git

--- a/infrastructure.md
+++ b/infrastructure.md
@@ -20,7 +20,3 @@ Each validated pattern has infrastructure requirements. The majority of the vali
 ## Sizing
 
 In this section we provide general minimum sizing requirements for such infrastructure but it is important to review specific requirements for a specific validated pattern. For example, [Industrial Edge 2.0](industrial-edge/index.md) employs AI/Ml technology that requires large machine instances to support the applications deployed on OpenShift at the datacenter.
-
-* [OpenShift Cluster General Sizing](infrastructure/ocp-cluster-general-sizing.md)
-* [RHEL for Edge](infrastructure/rhel-for-edge-general-sizing.md)
-

--- a/multicloud-gitops/getting-started.md
+++ b/multicloud-gitops/getting-started.md
@@ -70,10 +70,10 @@ service](https://console.redhat.com/openshift/create).
    oc login
    ```
 
-   or
+   or set KUBECONFIG to the path to your `kubeconfig` file. For example:
 
    ```sh
-   export KUBECONFIG=~/my-ocp-env/datacenter
+   export KUBECONFIG=~/my-ocp-env/hub/auth/kubconfig
    ```
 
 1. Apply the changes to your cluster
@@ -108,12 +108,12 @@ service](https://console.redhat.com/openshift/create).
 
    ```sh
    NAME                       HOST/PORT                                                                                         PATH      SERVICES                   PORT    TERMINATION            WILDCARD
-   datacenter-gitops-server   datacenter-gitops-server-industrial-edge-datacenter.apps.mycluster.mydomain.com          datacenter-gitops-server   https   passthrough/Redirect   None
+   hub-gitops-server          hub-gitops-server-industrial-edge-hub.apps.mycluster.mydomain.com          hub-gitops-server   https   passthrough/Redirect   None
    # admin.password
    2F6kgITU3DsparWyC
 
    NAME                    HOST/PORT                                                                                   PATH   SERVICES                PORT    TERMINATION            WILDCARD
-   edge-gitops-server   edge-gitops-server-industrial-edge-edge.apps.mycluster.mydomain.com          edge-gitops-server   https   passthrough/Redirect   None
+   region-one-gitops-server      region-one-gitops-server-industrial-edge-region-one.apps.mycluster.mydomain.com          region-one-gitops-server   https   passthrough/Redirect   None
    # admin.password
    K4ctDIm3fH7ldhs8p
 


### PR DESCRIPTION
Multicloud GitOps is using different labels for clusters. 
IE 2.0 main is broken and so changed instructions to clone branch stable-2.0