### PR TITLE
Just minor typo fixes + end of line whitespace removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project contains the documentation for hybrid-cloud-patterns.io
 
-The directory structure is pretty straightforward. The images dir are where images used in the documentation are loaded and referenced. Each validated pattern receives its own directory that includes an index.md file and any other files needed fo explain the pattern. 
+The directory structure is pretty straightforward. The images dir are where images used in the documentation are loaded and referenced. Each validated pattern receives its own directory that includes an index.md file and any other files needed to explain the pattern.
 
 The project colors are:
 - Grey #2D3B44

--- a/_posts/2021-11-1-dummy.md
+++ b/_posts/2021-11-1-dummy.md
@@ -12,4 +12,4 @@ tags:
 
 This project contains the documentation for hybrid-cloud-patterns.io
 
-The directory structure is pretty straightforward. The images dir are where images used in the documentation are loaded and referenced. Each validated pattern receives its own directory that includes an index.md file and any other files needed fo explain the pattern. 
+The directory structure is pretty straightforward. The images dir are where images used in the documentation are loaded and referenced. Each validated pattern receives its own directory that includes an index.md file and any other files needed to explain the pattern.

--- a/_posts/2021-11-17-dummy.md
+++ b/_posts/2021-11-17-dummy.md
@@ -12,4 +12,4 @@ tags:
 
 This project contains the documentation for hybrid-cloud-patterns.io
 
-The directory structure is pretty straightforward. The images dir are where images used in the documentation are loaded and referenced. Each validated pattern receives its own directory that includes an index.md file and any other files needed fo explain the pattern. 
+The directory structure is pretty straightforward. The images dir are where images used in the documentation are loaded and referenced. Each validated pattern receives its own directory that includes an index.md file and any other files needed to explain the pattern.

--- a/building-vps/getting-started.md
+++ b/building-vps/getting-started.md
@@ -5,7 +5,7 @@ parent: Creating a new pattern
 nav_order: 2
 ---
 
-# Getting started creating a new pattern  
+# Getting started creating a new pattern
 {: .no_toc }
 
 ## Table of contents
@@ -18,7 +18,7 @@ nav_order: 2
 Please make sure you ave read the [introduction section](/creating-a-new-pattern.md) and the [structure](building-vps/structure.md) section of this documentation.
 
 # You're probably not starting from scratch
-The validated patterns community has relied on existing architectures that have been succesfully deployed in an enterprise. The architecture itself is a best practice in assembling technologies and projects to provide a working solution. How that solution is deployed and managed is a different matter. It may have evolved over time and may have grown in its deployment such that ongoing maintenance is not sustainable. 
+The validated patterns community has relied on existing architectures that have been successfully deployed in an enterprise. The architecture itself is a best practice in assembling technologies and projects to provide a working solution. How that solution is deployed and managed is a different matter. It may have evolved over time and may have grown in its deployment such that ongoing maintenance is not sustainable.
 
 The validated patterns framework is much more of a best practice of structuring the various configuration assets and integrating with GitOps and DevOps tools.
 
@@ -27,7 +27,7 @@ Therefore the question really is: how do I move my successful architecture solut
 # Moving to the validated patterns framework
 One of the first things that you should do is look at your current implementation of your workload and identify the kubernetes manifests that are involved in order to run the workloads.
 
-## When and how to use `values-` files. 
+## When and how to use `values-` files.
 There are 4 values files that make up any Validated Pattern.  The values files are:
 * values-<main-hub>.yaml  (e.g. values-datacenter.yaml)
 * values-<edge>.yaml (e.g. values-edge-site.yaml or values-factory.yaml)
@@ -36,9 +36,9 @@ There are 4 values files that make up any Validated Pattern.  The values files a
 
 
 ## Operators into framework
-We begin our journey by identifying what application services are needed to run the workload.  The Cloud Native Operator framework provides a way of managing the lifecycle of application services that are needed by the application workload.  The validated pattern framework gives you a way to describe these Operators in a values file that is specific to your pattern and ithe site type.
+We begin our journey by identifying what application services are needed to run the workload.  The Cloud Native Operator framework provides a way of managing the lifecycle of application services that are needed by the application workload.  The validated pattern framework gives you a way to describe these Operators in a values file that is specific to your pattern and the site type.
 
-So for example if we wish deploy Advanced Cluster Management, AMQ (messaging) and AMQ Streams (Kafka) in our datacetner, we would make the following subscription entries in our `values-datacenter.yaml` file:
+So for example if we wish deploy Advanced Cluster Management, AMQ (messaging) and AMQ Streams (Kafka) in our datacenter, we would make the following subscription entries in our `values-datacenter.yaml` file:
 ```yaml
 namespaces:
   - open-cluster-management
@@ -59,19 +59,19 @@ subscriptions:
   - name: amq-broker
     namespace: my-application
     channel: 7.8.x
-    csv: amq-broker-operator.v7.8.1-opr-3        
+    csv: amq-broker-operator.v7.8.1-opr-3
 ```
 This tells the framework which Operators are needed and what namespace they should be deployed in.
 
 ## Grouping applications for OpenShift GitOps
 In the same values- file we need to inform OpenShift GitOps (ArgoCD) what applications to deploy and where the Helm Charts are so that they can be applied to the deployment and watched for future changes.
 
-When using GitOps and specificall OpenShift GitOps (ArgoCD) it makes sense to break up applications into different areas of concern, i.e. projects. For example the main applications for the datacenter might be grouped seperately from some storage components
+When using GitOps and specifically OpenShift GitOps (ArgoCD) it makes sense to break up applications into different areas of concern, i.e. projects. For example the main applications for the datacenter might be grouped separately from some storage components
 ```yaml
 projects:
 - datacenter
 - storage
- 
+
 applications:
 - name: acm
   namespace: open-cluster-management
@@ -116,16 +116,16 @@ In the above example `acm` (ACM) is part of the main `datacenter` deployment, as
 
 The `path:` tag tells OpenShift GitOps where to find the Helm charts needed to deploy this application (refer back to the [charts directory description](https://hybrid-cloud-patterns.io/building-vps/structure/#the-charts-directory) for more details). OpenShift GitOps will continuously monitor for changes to artifacts in that location for updates to apply.
 
-Each different site type would have it's own values- file listing subscriptions and applications. 
+Each different site type would have it's own values- file listing subscriptions and applications.
 
 ## Scripts to framework
 
 ## Ansible to Framework
 
 ## Kustomize to framework
-Kustomize can still be used within the framework but it will be driven by Helm. If you have a lot of `kustomization.yaml` you may not need to refactor all of it. However you will need a Helm chart to drive it and you will need to check for names and paths etc. that you may need to parameterize using the Helm templates capabilities. 
+Kustomize can still be used within the framework but it will be driven by Helm. If you have a lot of `kustomization.yaml` you may not need to refactor all of it. However you will need a Helm chart to drive it and you will need to check for names and paths etc. that you may need to parameterize using the Helm templates capabilities.
 
-For example the original ArgoCD subscription YAML from one of the patterns looked like this:  
+For example the original ArgoCD subscription YAML from one of the patterns looked like this:
 ``` yaml
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -140,7 +140,7 @@ spec:
   sourceNamespace: openshift-marketplace
   startingCSV: argocd-operator.v0.0.11
 ```
-While we could have continued to use the ArgoCD community operator we transitioned to using OpenShift GitOps, the Red Hat supported product. But this static subscription would not allow updates for continuous integration of new versions. And You'll remmeber from the Operators section above that we specify channel names as part of the subscription of operators. So we can instead usin something like this (understanding the move to openshift-gitops-operator instead of argocd).
+While we could have continued to use the ArgoCD community operator we transitioned to using OpenShift GitOps, the Red Hat supported product. But this static subscription would not allow updates for continuous integration of new versions. And you'll remember from the Operators section above that we specify channel names as part of the subscription of operators. So we can instead using something like this (understanding the move to openshift-gitops-operator instead of ArgoCD).
 
 ```yaml
 apiVersion: operators.coreos.com/v1alpha1
@@ -163,7 +163,7 @@ spec:
 
 # Lessons learned
 ## Size matters
-If things are taking a long time to dpleoy, use the OpenShift console to check on memory and other potential capacity issues with the cluster. If running in a cloud you may wish to up the machine size. Check the [sizing charts](https://hybrid-cloud-patterns.io/infrastructure/).
+If things are taking a long time to deploy, use the OpenShift console to check on memory and other potential capacity issues with the cluster. If running in a cloud you may wish to up the machine size. Check the [sizing charts](https://hybrid-cloud-patterns.io/infrastructure/).
 
 
 

--- a/building-vps/structure.md
+++ b/building-vps/structure.md
@@ -5,7 +5,7 @@ parent: Creating a new pattern
 nav_order: 1
 ---
 
-# Validated pattern structure  
+# Validated pattern structure
 {: .no_toc }
 
 ## Table of contents
@@ -15,16 +15,16 @@ nav_order: 1
 {:toc}
 
 ## Framework fundamentals
-The validated patterns framework uses [OpenShift GitOps](https://docs.openshift.com/container-platform/4.9/cicd/gitops/understanding-openshift-gitops.html) (ArgoCD) as the primary driver for deploying patterns and keeping them up to date. Validated patterns use Helm charts as the primary artifacts for GitOps. [Helm charts](https://helm.sh/) provide a mechanism for templating that is very powerful when building repeatable, automated deployments across different deployment environements (i.e. clouds, data centers, edge, etc.)
+The validated patterns framework uses [OpenShift GitOps](https://docs.openshift.com/container-platform/4.9/cicd/gitops/understanding-openshift-gitops.html) (ArgoCD) as the primary driver for deploying patterns and keeping them up to date. Validated patterns use Helm charts as the primary artifacts for GitOps. [Helm charts](https://helm.sh/) provide a mechanism for templating that is very powerful when building repeatable, automated deployments across different deployment environments (i.e. clouds, data centers, edge, etc.)
 
-Many Cloud Native Computing Foundation (CNCF) projects use [Operators](https://operatorframework.io/) to manage the lifecycle of their service. Whenever possible the validated patterns will  ake use of these Operators to deploy the application service. 
+Many Cloud Native Computing Foundation (CNCF) projects use [Operators](https://operatorframework.io/) to manage the lifecycle of their service. Whenever possible the validated patterns will make use of these Operators to deploy the application service.
 
 [Red Hat Advanced Cluster Management](https://www.redhat.com/en/technologies/management/advanced-cluster-management) (ACM) is primarily used to automate the deployment of edge clusters. It provides subscription information for specific deployment sites.
 
 [OpenShift Pipelines](https://docs.openshift.com/container-platform/4.9/cicd/pipelines/understanding-openshift-pipelines.html) is used to automate builds and keep image repositories up to date.
 
 ## Pattern directories tour
-Examining any of the existing patterns reveals the important organizational part of the validated patterns framework. Let's take a look at a couple of the existing validated patterns: Multicluster GitOps and Industrial Edge. 
+Examining any of the existing patterns reveals the important organizational part of the validated patterns framework. Let's take a look at a couple of the existing validated patterns: Multicluster GitOps and Industrial Edge.
 
 ```
 ~/g/multicloud-gitops on main ◦ tree -L 2                                                                                                          12:32:12
@@ -99,15 +99,15 @@ First we notice some `values-` yaml files and subdirectories: charts, common and
 We see the same or similar files in the Industrial Edge pattern above.
 
 ## The `charts` directory
-This is where validated patterns keep the helm charts for a pattern. The helm charts are used deploy and manage the various components of the apllications deployed at a site. By convention, the charts are broken out by site location. So you may see `datacenter` or `hub` or `factory` or other site names in there.
+This is where validated patterns keep the helm charts for a pattern. The helm charts are used deploy and manage the various components of the applications deployed at a site. By convention, the charts are broken out by site location. So you may see `datacenter` or `hub` or `factory` or other site names in there.
 
-Each site has sub-directories based on application or library component groupings. 
+Each site has sub-directories based on application or library component groupings.
 
 From [Helm documentation:](https://helm.sh/docs/chart_template_guide/getting_started/)
-*Application charts* are a collection of templates that can be packaged into versioned archives to be deployed. 
+*Application charts* are a collection of templates that can be packaged into versioned archives to be deployed.
 
 *Library charts* provide useful utilities or functions for the chart developer. They're included as a dependency of application charts to inject those utilities and functions into the rendering
-pipeline. Library charts do not define any templates and therefore cannot be deployed. 
+pipeline. Library charts do not define any templates and therefore cannot be deployed.
 
 These groupings are used by OpenShift GitOps to deploy into the cluster. The  configurations for each of the components inside an application are synced every three minutes by OpenShift GitOps to make sure that the site is up to date. The configuration can also be synced manually if you do not wish to wait up to three minutes.
 
@@ -119,29 +119,29 @@ The configuration YAML for each of the component of the application is stored in
 
 
 
-## The `common` directoy
-There are many common components that are in use across the validated patterns that exist today. E.g. AMQ Streams (Kafka) and ACM. We expect these common components to grow. Rather than duplicating the configuration in each pattern, common technologies are moved into a common directory.  If there are pattern specific post deployment configurations to be applied then those woul dbe added to the Helm charts in `charts` directory structure. 
+## The `common` directory
+There are many common components that are in use across the validated patterns that exist today. E.g. AMQ Streams (Kafka) and ACM. We expect these common components to grow. Rather than duplicating the configuration in each pattern, common technologies are moved into a common directory.  If there are pattern specific post deployment configurations to be applied then those would be added to the Helm charts in `charts` directory structure.
 
 ## The `scripts` directory
 Sometimes an Operator and/or the Helm charts still leave some work to be done with regard to final configuration. When extra code is needed to deploy then that extra code is placed in the `scripts` directory. The majority of the time a consumer of a validated pattern will only use this code through the existing automation. i.e. The `Makefile` or OpenShift GitOps will make use of these scripts. So if there is extra *massaging* required for your application, but the scripts in here and try to run them from within the automation.
 
 ## Applications and `values-` files
-Helm uses `values.yaml` files to pass values into charts. Values in the `values.yaml` file can be overriden in the following ways:
+Helm uses `values.yaml` files to pass values into charts. Values in the `values.yaml` file can be overridden in the following ways:
 1. By a `values.yaml` file in the parent directory
 1. By a values file passed into the `helm <install/upgrade>` command using `-f`
 1. By specifying an override individual value in the the `helm` command with `--set`
 
-For more information on values files and their usage see the [values files section](https://helm.sh/docs/chart_template_guide/values_files/) of the Helm documentaion.
+For more information on values files and their usage see the [values files section](https://helm.sh/docs/chart_template_guide/values_files/) of the Helm documentation.
 
 This section is meant as an introduction to the `values-` files that the framework uses to override values int he chart templates. In the Getting Started pages there will be more specific usage details.
 
 There are three types of `value-` files.
 1. `values-global.yaml`
-	This is used to set variables for helm charts across the pattern. It contains the name of the pattern and sets some other variables for artifacts like, image registry, Git repositories, GitOps syncPolicy etc. 
+	This is used to set variables for helm charts across the pattern. It contains the name of the pattern and sets some other variables for artifacts like, image registry, Git repositories, GitOps syncPolicy etc.
 1. `values-<site>.yaml`
-	Each specific site requires information regarding what applications and subscriptions are required for that site. So this file contains a list of namespaces, applications, subscriptions, the operator versions etc. for that site. 
+	Each specific site requires information regarding what applications and subscriptions are required for that site. So this file contains a list of namespaces, applications, subscriptions, the operator versions etc. for that site.
 1. `values-secret.yaml.template`
-	Some patterns are not using a [secrets management](/secrets.md) service like [Hashicorp Vault](/secrets/vault.md). As you create a new pattern you may need to get it up and going quickly and hard code some secrets that you DO NOT want to share or push to a Git repo. This template file can be copied to your homne directory, the secret values applied, and the validated pattern will go look for `values-secrets.yaml` in your home directory. Do not leave a `values-secrets.yaml` file in your cloned git directory or it may end up in your (often public) Git repo, like GitHub.  
+	Some patterns are not using a [secrets management](/secrets.md) service like [Hashicorp Vault](/secrets/vault.md). As you create a new pattern you may need to get it up and going quickly and hard code some secrets that you DO NOT want to share or push to a Git repo. This template file can be copied to your home directory, the secret values applied, and the validated pattern will go look for `values-secrets.yaml` in your home directory. Do not leave a `values-secrets.yaml` file in your cloned git directory or it may end up in your (often public) Git repo, like GitHub.
 
 ## Applications & subscriptions
 
@@ -169,7 +169,7 @@ spec:
   wildcardPolicy: None
   ```
 
-The values in the `values-global.yaml` will be substitued when the YAML is applied to the cluster. 
+The values in the `values-global.yaml` will be substituted when the YAML is applied to the cluster.
 
 ```
 global:

--- a/creating-a-new-pattern.md
+++ b/creating-a-new-pattern.md
@@ -16,41 +16,41 @@ has_children: true
 
 ## Introduction to pattern creation
 
-This section provides the details on how to create a new pattern using the validated patterns framework. Creating a new pattern might start from scratch or it maybe be from an existing deployment that would benefit from a repeatable framework based on GitOps. 
+This section provides the details on how to create a new pattern using the validated patterns framework. Creating a new pattern might start from scratch or it maybe be from an existing deployment that would benefit from a repeatable framework based on GitOps.
 
-This introduction explains some of framework design decisions and why they were chosen. There are some high level concepts that are required for the framework. While those concepts can be implemented using a variety of open source projects, this framework is prescriptive and so mentions the project and also (down stream) product that was used. E.g. For development builds we us Tekton (project) and specifically OpenShift Pipelines (product). 
+This introduction explains some of framework design decisions and why they were chosen. There are some high level concepts that are required for the framework. While those concepts can be implemented using a variety of open source projects, this framework is prescriptive and so mentions the project and also (down stream) product that was used. E.g. For development builds we us Tekton (project) and specifically OpenShift Pipelines (product).
 
 The framework uses popular Cloud Native Computing Foundation (CNCF) [projects](https://landscape.cncf.io/) as much as possible. The CNCF landscape also contains lots of projects that solve the same or similar problem. The validated patterns effort has chosen specific projects but it is not unreasonable for users to switch out one project for another. (See more on Operators below).
 
-There is no desire to replicate efforts already in CNCF. If new a open source project comes out of this framework, the plan would be to contribute that to CNCF. 
+There is no desire to replicate efforts already in CNCF. If new a open source project comes out of this framework, the plan would be to contribute that to CNCF.
 
 ## Who creates patterns?
 
 Many enterprise class Cloud Native applications are complex and require man different application services integrated together. Organizations can learn from each other on how to create robust, scalable and maintainable systems. When you find a pattern that seems to work, it makes sense to promote best practices to others in order for them to not repeat the many failures you probably made while getting to your killer pattern.
 
-In the world of DevOps (including DevSecOps and GitOps) teams should include personnel from development, operations, security, and architects. What makes DevOps work is the collaboration of all these IT personnel and the business owners and others. As DevOps practices move through your organization, best practices are shared and standards evolve. 
+In the world of DevOps (including DevSecOps and GitOps) teams should include personnel from development, operations, security, and architects. What makes DevOps work is the collaboration of all these IT personnel and the business owners and others. As DevOps practices move through your organization, best practices are shared and standards evolve.
 
 This validate patterns framework has evolved since it was started in 2019. It will likely continue to evolve. But what was learned is that there are some common concepts that need to be addressed once you desire to generalize your organizations framework.
 
-Therefore, the goal is, that developers, operators and architects will use this framework to have secure and repeatable day one deployment mechanism and maintenance automation for day two operations. 
+Therefore, the goal is, that developers, operators and architects will use this framework to have secure and repeatable day one deployment mechanism and maintenance automation for day two operations.
 
 ## A common platform
 
 One of the most important goals of this framework is to provide consistency across any cloud provider - public or private. Public cloud providers each have Kubernetes distributions. And while they keep up with the Kubernetes release cycle, they are not always running on the same version. Furthermore each cloud provider provides their own sets of services that developers often consume. So while you could automate the difference handling for each of the cloud providers, the framework utilizes one Kubernetes distribution that runs on public or private clouds - the hybrid and/or multi cloud model.
 
-The framework depends on Red Hat OpenShift Container Platform (OCP). Once you have deployed Red Hat OCP wherever you wish to deploy your cloud native application pattern, then the framework can deploy on that platform in a few easy steps.      
+The framework depends on Red Hat OpenShift Container Platform (OCP). Once you have deployed Red Hat OCP wherever you wish to deploy your cloud native application pattern, then the framework can deploy on that platform in a few easy steps.
 
 ## Containment beyond containers
 
-If you are reading this chances are you are already familiar with Linux containers. But there is more to containers than Linus containers in the Cloud Native environment. 
+If you are reading this chances are you are already familiar with Linux containers. But there is more to containers than Linus containers in the Cloud Native environment.
 
 ### Containers
 Containers allow you to encapsulate your program/process, and all its dependencies in one package called a container image. The container runtime starts an instance of this container using only the Linux kernel and the directory structure, with program and dependencies, provided in the container image. This ensures that the program is running isolated from any other packages, programs or files loaded on the host system.
 
-Kubernetes, and the Cloud Native community of services, use Linux containers as their basic building block. 
+Kubernetes, and the Cloud Native community of services, use Linux containers as their basic building block.
 
 ### Operators
-While Linux containers provide an incredibly useful way to isolate the dependencies for an application or application service, containers also require some life cycle management. For example, at start up a container my need to set up access to networks, or extra storage. This type of set up usually happens with a human operator decided on how the container will connect networks or host storage. The operator may also have to do routine maintenance. For example if the container contains a database, the human operator may need to do a backup or routine scrubbing of the database. 
+While Linux containers provide an incredibly useful way to isolate the dependencies for an application or application service, containers also require some life cycle management. For example, at start up a container my need to set up access to networks, or extra storage. This type of set up usually happens with a human operator decided on how the container will connect networks or host storage. The operator may also have to do routine maintenance. For example if the container contains a database, the human operator may need to do a backup or routine scrubbing of the database.
 
 Kubernetes [Operators](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) is an extension to Kubernetes *"that make sue of custom resources to manage applications and their components."* I.e. it provides and extra layer of encapsulation on top of containers that packages up some operation automation with the container. It puts what the human operator would do into an Operator pattern for the service or set of services.
 
@@ -59,31 +59,31 @@ Many software providers/vendors have created operators to manage their applicati
 
 
 ### Validated patterns
-Assembling operators into a common pattern provides another layer of encapsulation. As with an Operator, where the developer can take advantage of the best practices from a experienced human operator, a validated pattern provides a way of taking advantage of best practices for deploying operators and other assets for a particular type of solution. Rather than starting from scratch to figure out how to deploy and manage a complex set of integrated and dependent containerized services, a developer can take a validated pattern and know that a lot of experience has been put into it. 
+Assembling operators into a common pattern provides another layer of encapsulation. As with an Operator, where the developer can take advantage of the best practices from a experienced human operator, a validated pattern provides a way of taking advantage of best practices for deploying operators and other assets for a particular type of solution. Rather than starting from scratch to figure out how to deploy and manage a complex set of integrated and dependent containerized services, a developer can take a validated pattern and know that a lot of experience has been put into it.
 
 [![Validated pattern stack](/images/framework/validated-patterns-stack.png)](/images/framework/validated-patterns-stack.png)
 
-A validated pattern has been tested and continues to be tested as the life cycle of individual parts (Operators) change through release cycles. Red Hat's Quality Engineering team provides Continuous Integration of the pattern for new releases of Red Hat products (Operators). 
+A validated pattern has been tested and continues to be tested as the life cycle of individual parts (Operators) change through release cycles. Red Hat's Quality Engineering team provides Continuous Integration of the pattern for new releases of Red Hat products (Operators).
 
 The validated patterns framework takes advantage of automation technology. It uses Cloud Native automation technology as much as possible. Occasionally the framework resorts to some scripts in order to get a pattern up and running faster.
 
 ## Automation has many layers
 
-As mentioned above gaining consistency and robustness for deploying complex Cloud Native applications requires automation. While it many Kubernetes distributions, including OpenShift, provide excellent user interfaces for deploying and managing applications, this is mostly useful during development and/or debugging when things go wrong. Being able to consistently deploy complex applications is critical. 
+As mentioned above gaining consistency and robustness for deploying complex Cloud Native applications requires automation. While it many Kubernetes distributions, including OpenShift, provide excellent user interfaces for deploying and managing applications, this is mostly useful during development and/or debugging when things go wrong. Being able to consistently deploy complex applications is critical.
 
-But which automation tool should be used? Or which automation tools, plural? During the development of the validated patterns framework we learned important lessons on the different areas of automation. 
+But which automation tool should be used? Or which automation tools, plural? During the development of the validated patterns framework we learned important lessons on the different areas of automation.
 
 ### Automation for building application code
 When developing container based Cloud Native applications a developer needs build executable code and create a new container image for deployment into their Kubernetes test environment. Once tested, that container image needs to be moved through the continuous integration and continuous deployment (CI/CD) pipeline until it ends up in production. [Tekton](https://tekton.dev/) is a Cloud Native CI/CD project that is build for hybrid-cloud. [OpenShift Pipelines](https://cloud.redhat.com/learn/topics/ci-cd) is a Red Hat product based on Tekton.
 
 ### Automation for application operations
-There are two aspects to consider for operations when doing automation. First you must be able to package up much of the configuration that is required for deploying Operators and pods. The validated patterns framework started with a project called Kustomize which allows you to assemble complex deployment YAML to apply to your Kubernetes cluster. Kustomize is a powerful tool, and almost achieved what we needed. However it fell short when we needed to propagate variable data into our deployment YAML. Instead we chose [Helm](https://cloud.redhat.com/learn/topics/helm) because it provides templating and can therefore handle the injection of variable data into the deployment package. See more on templating [here](). 
+There are two aspects to consider for operations when doing automation. First you must be able to package up much of the configuration that is required for deploying Operators and pods. The validated patterns framework started with a project called Kustomize which allows you to assemble complex deployment YAML to apply to your Kubernetes cluster. Kustomize is a powerful tool, and almost achieved what we needed. However it fell short when we needed to propagate variable data into our deployment YAML. Instead we chose [Helm](https://cloud.redhat.com/learn/topics/helm) because it provides templating and can therefore handle the injection of variable data into the deployment package. See more on templating [here]().
 
-The second aspect of automation for application automation deals with both workflow and GitOps. Validated patterns requires that a workflow deploys various components of the complex application. Visibility into the success or failure of those application components is really important. After the intial deployment it is important to role out configuration changes in an automated way using a code repository. This is achieved using GitOps. i.e. Using a Git repository as a mechanism to change configuration that triggers the automatic roll-out of those changes. 
+The second aspect of automation for application automation deals with both workflow and GitOps. Validated patterns requires that a workflow deploys various components of the complex application. Visibility into the success or failure of those application components is really important. After the initial deployment it is important to role out configuration changes in an automated way using a code repository. This is achieved using GitOps. i.e. Using a Git repository as a mechanism to change configuration that triggers the automatic roll-out of those changes.
 
 *"Application definitions, configurations, and environments should be declarative and version controlled. Application deployment and lifecycle management should be automated, auditable, and easy to understand."*  - Argo CD project
 
-OpenShift GitOps is based on the [Argo CD](https://argo-cd.readthedocs.io/en/stable/) project. It is a GitOps continuous delivery tool for Kubernetes. 
+OpenShift GitOps is based on the [Argo CD](https://argo-cd.readthedocs.io/en/stable/) project. It is a GitOps continuous delivery tool for Kubernetes.
 
 ## Secret handling
 Validated patterns often depend on resources that require certificates or keys. These secrets need to be handled carefully. And while it's tempting to focus on just the deployment of the pattern and "handle security later", that's a really bad idea. In the spirit of DevSecOps the validated patterns effort has decided to "shift security left". i.e. build security in early in the life cycle.
@@ -97,11 +97,11 @@ There are two approaches to secret handling with validated:
 Some of the validated patterns use configuration files (for now), while others, like the [Multicloud GitOps](https://hybrid-cloud-patterns.io/multicloud-gitops/) uses Vault. *TBD add a link to the Vault set up page here when completed*
 
 ## Policy
-While many enterprise Cloud Native applications use open source, many of the products used require licenses or subscriptions. Policies help enforce license and subscription management and the channels needed to get access to those licenses or subscriptions. 
+While many enterprise Cloud Native applications use open source, many of the products used require licenses or subscriptions. Policies help enforce license and subscription management and the channels needed to get access to those licenses or subscriptions.
 
-Similarliy in a multicloud deployments and complex edge deployments policies can help define and select the correct GitOps workflows that need to be managed for various sites or clusters. E.g. defining an OpenShift Cluster as a "Factory" in the [Industrial Edge](https://hybrid-cloud-patterns.io/industrial-edge/factory/) validated pattern provides a simple trigger to rollout the entire Factory deployment. Policy is a very powerful tool in automation.
+Similarly in a multicloud deployments and complex edge deployments policies can help define and select the correct GitOps workflows that need to be managed for various sites or clusters. E.g. defining an OpenShift Cluster as a "Factory" in the [Industrial Edge](https://hybrid-cloud-patterns.io/industrial-edge/factory/) validated pattern provides a simple trigger to roll-out the entire Factory deployment. Policy is a very powerful tool in automation.
 
-Validated patterns uses [Red Hat Advanced Cluster Management for Kubernetes](https://www.redhat.com/en/technologies/management/advanced-cluster-management) to control clusters and applications from a single console, with built in security policies. 
+Validated patterns uses [Red Hat Advanced Cluster Management for Kubernetes](https://www.redhat.com/en/technologies/management/advanced-cluster-management) to control clusters and applications from a single console, with built in security policies.
 
 
 

--- a/faq.md
+++ b/faq.md
@@ -8,7 +8,7 @@ nav_order: 9
 
 ## What is a Hybrid Cloud Pattern?
 
-Hybrid Cloud Patterns are collections of applications (in the ArgoCD sense) that demonstrate aspects of hub/edge computing that seem interesting and useful.  Hybrid Cloud Patterns will generall have a hub or centralized component, and an edge component.  These will interact in different ways.
+Hybrid Cloud Patterns are collections of applications (in the ArgoCD sense) that demonstrate aspects of hub/edge computing that seem interesting and useful.  Hybrid Cloud Patterns will generally have a hub or centralized component, and an edge component.  These will interact in different ways.
 
 Many things have changed in the IT landscape in the last few years - containers and kubernetes have taken the industry by storm, but they introduce many technologies and concepts.  It is not always clear how these technologies and concepts play together - and Hybrid Cloud Patterns is our effort to show these technologies working together on non-trivial applications in ways that make sense for real customers and partners to use.
 
@@ -41,7 +41,7 @@ Hybrid Cloud Patterns come in parts - we have a [common](https://github.com/hybr
 
 The common repo is primarily concerned with how to deploy the GitOps operator, and to create the namespaces that will be necessary to manage the pattern applications.
 
-The pattern repo has the application-specific layout, and determines which components are installed in which places - hub or edge.  The pattern repo also defines the hub and edge locations.  Both the hub and edge are expected to have multiple components each - the hub will have pipelines and the CI/CD framework, as well as any centralization components or data analysis componenets.  Edge components are designed to be smaller as we do not need to deploy Pipelines or the test and staging areas to the Edge.
+The pattern repo has the application-specific layout, and determines which components are installed in which places - hub or edge.  The pattern repo also defines the hub and edge locations.  Both the hub and edge are expected to have multiple components each - the hub will have pipelines and the CI/CD framework, as well as any centralization components or data analysis components.  Edge components are designed to be smaller as we do not need to deploy Pipelines or the test and staging areas to the Edge.
 
 Each application is described as a series of resources that are rendered into GitOps (ArgoCD) via Helm and Kustomize.  The values for these charts are set by values files that need to be "personalized" (with your local cluster values) as the first step of installation.  Subsequent pushes to the gitops repo will be reflected in the clusters running the applications.
 

--- a/index.md
+++ b/index.md
@@ -17,15 +17,15 @@ The automation also enables the solution to be added to Continuous Integration (
 
 ## Who should use these patterns?
 
-It is recommended that architects or advanced developers with knowledge of Kubernetes and Red Hat OpenShift Container Platform use these patterns. There are advanced [Cloud Native](https://www.cncf.io/projects/) concepts and projects deployed as part of the pattern framework. These include, but are not limited to, OpenShift Gitops ([ArgoCD](https://argoproj.github.io/argo-cd/)), Advanced Cluster Management ([Open Cluster Management](https://open-cluster-management.io/)), and OpenShift Pipelines ([Tekton](https://tekton.dev/)) 
+It is recommended that architects or advanced developers with knowledge of Kubernetes and Red Hat OpenShift Container Platform use these patterns. There are advanced [Cloud Native](https://www.cncf.io/projects/) concepts and projects deployed as part of the pattern framework. These include, but are not limited to, OpenShift Gitops ([ArgoCD](https://argoproj.github.io/argo-cd/)), Advanced Cluster Management ([Open Cluster Management](https://open-cluster-management.io/)), and OpenShift Pipelines ([Tekton](https://tekton.dev/))
 
 ## General Structure
 
-All patterns assume an OpenShift cluster is available to deploy the application(s) that are part of the pattern. If you do not have an openshift cluster you can use [cloud.redhat.com](https://console.redhat.com/openshift). 
+All patterns assume an OpenShift cluster is available to deploy the application(s) that are part of the pattern. If you do not have an openshift cluster you can use [cloud.redhat.com](https://console.redhat.com/openshift).
 
 The documentation will use the `oc` command syntax but `kubectl` can be used interchangeably. For each deployment it is assumed that the user is logged into a cluster using the `oc login` command or by exporting the `KUBECONFIG` path.
 
-The diagram below outlines the general deployment flow of a datacenter application. 
+The diagram below outlines the general deployment flow of a datacenter application.
 
 But first the user must create a fork of the pattern repository. This allows changes to be made to operational elements (configurations etc.) and to application code that can then be successfully made to the forked repository for DevOps continuous integration (CI). Clone the directory to your laptop/desktop. Future changes can be pushed to your fork.
 
@@ -35,13 +35,13 @@ But first the user must create a fork of the pattern repository. This allows cha
 
 	2. Deploy the application as specified by the pattern. This may include a Helm command (`helm install`) or a make command (`make deploy`).
 
-When the workload is deployed the pattern first deploys OpenShift GitOps. OpenShift GitOps will then take over and make sure that all application and the components of the pattern are deployed. This includes required operators and applicatioon code. 
+When the workload is deployed the pattern first deploys OpenShift GitOps. OpenShift GitOps will then take over and make sure that all application and the components of the pattern are deployed. This includes required operators and application code.
 
-Most patterns will have an Advanced Cluster Management operator deployed so that multi-cluster deployments can be managed. 
+Most patterns will have an Advanced Cluster Management operator deployed so that multi-cluster deployments can be managed.
 
 ## Edge Patterns
 
-Some patterns include both a data center and one or more edge clusters. The diagram below outlines the general deployment flow of applications on an edge application. The edge OpenShift cluster is often deployed on a smaller cluster than the datacenter. Sometimes this might be a three node cluster that allows workloads to be deployed on the master nodes. The edge cluster might be a single node cluster (SN0). It might be deployed on bare metal, on local virtual machines or in a public/private cloud. Provision the cluster (see above) 
+Some patterns include both a data center and one or more edge clusters. The diagram below outlines the general deployment flow of applications on an edge application. The edge OpenShift cluster is often deployed on a smaller cluster than the datacenter. Sometimes this might be a three node cluster that allows workloads to be deployed on the master nodes. The edge cluster might be a single node cluster (SN0). It might be deployed on bare metal, on local virtual machines or in a public/private cloud. Provision the cluster (see above)
 
 ![GitOps for Edge](./images/gitops-edge.png)
 
@@ -51,4 +51,4 @@ When the cluster is imported, ACM on the datacenter will deploy an ACM agent and
 
 ## OpenShift GitOps (a.k.a ArgoCD)
 
-When OpenShift GitOps is deployed and running in a cluster (datacenter or edge) you can launch it's console by  choosing ArgoCD in the upper left part of the OpenShift Console (TO-DO whenry to add an image and clearer instructions here)  
+When OpenShift GitOps is deployed and running in a cluster (datacenter or edge) you can launch it's console by  choosing ArgoCD in the upper left part of the OpenShift Console (TO-DO whenry to add an image and clearer instructions here)

--- a/industrial-edge/application.md
+++ b/industrial-edge/application.md
@@ -6,7 +6,7 @@ parent: Industrial Edge
 nav_order: 3
 ---
 
-# Demonstrating Industrial Edge example applications  
+# Demonstrating Industrial Edge example applications
 {: .no_toc }
 
 ## Table of contents
@@ -21,7 +21,7 @@ Up until now the Industrial Edge 2.0 validated patterns has focused primarily on
 
 If you have already deployed the data center and optionally a factory (edge) cluster, then you have already seen several applications deployed in the OpenShift GitOps console. If you haven't done this then we recommend you deploy the data center after you have setup the Quay repositories described below.
 
-## Prerequiste preparation
+## Prerequisite preparation
 
 ### Quay public registry setup
 
@@ -30,7 +30,7 @@ In the [Quay.io](https://quay.io) registry please ensure you have the following 
 * _your-org_/iot-software-sensor
 * _your-org_/iot-consumer
 * _your-org_/iot-frontend
-* _your-org_/iot-anomoloy-detection
+* _your-org_/iot-anomaly-detection
 * _your-org_/http-ionic
 
 These repositories are needed in order to provide container images built at the data center to be consumed by the factories (edge).
@@ -63,7 +63,7 @@ Make sure you are able to see the dashboard application in a tab on your browser
 
 [![](/images/industrial-edge/network-routing-line-dashboard.png)](/images/industrial-edge/network-routing-line-dashboard.png)
 
-Select Networking->Routes on the lefthand side of the console. Using the Projects pull-down, select `manuela-tst-all`. Click on the URL under the Location column for the route Name `line-dashboard`. this will launch the line-dashboard monitoring application in a browser tab. The URL will look like:  
+Select Networking->Routes on the left-hand side of the console. Using the Projects pull-down, select `manuela-tst-all`. Click on the URL under the Location column for the route Name `line-dashboard`. this will launch the line-dashboard monitoring application in a browser tab. The URL will look like:
 
 line-dashboard-manuela-tst-all.apps.*cluster-name*.*domain*
 
@@ -98,9 +98,9 @@ Sometimes a page/tab refreshed is needed for the change to be picked up.
 
 ## Application changes using DevOps
 
-The `line-dashboard` application has temprature sensors. In this demonstation we are going to make a simple change to that application, rebuild and redeploy it. In the `manuela-dev` repository there is a file `components/iot-consumer/index.js`. This Javascript program consumes message data coming from the line servers and one of functions it performs is to check the temprature to see if it has exceeded a threshold. There is three lines of code in there that does some Celsius to Fahrenheit conversion.
+The `line-dashboard` application has temperature sensors. In this demonstration we are going to make a simple change to that application, rebuild and redeploy it. In the `manuela-dev` repository there is a file `components/iot-consumer/index.js`. This Javascript program consumes message data coming from the line servers and one of functions it performs is to check the temperature to see if it has exceeded a threshold. There is three lines of code in there that does some Celsius to Fahrenheit conversion.
 
-Depending on the state of your `manuela-dev` repository this may or may not be commented out. Ideally for the demonstration you would want it  uncommented and therefore effective.  What this means is that while the labels on the front-end application are showing Celsius, the data is actually in Fahrenheit. This is a good place to start because that data won't make any sense.  
+Depending on the state of your `manuela-dev` repository this may or may not be commented out. Ideally for the demonstration you would want it  uncommented and therefore effective.  What this means is that while the labels on the front-end application are showing Celsius, the data is actually in Fahrenheit. This is a good place to start because that data won't make any sense.
 
 [![](/images/industrial-edge/fahrenheit-temp.png)](/images/industrial-edge/fahrenheit-temp.png)
 
@@ -108,7 +108,7 @@ Machines running over 120C is not normal.  However examining the code explains w
 
 [![](/images/industrial-edge/uncommented-code.png)](/images/industrial-edge/uncommented-code.png)
 
-If you haven't deployed the uncommneted code it might be best to prepare that before the demonstration. After pointing out the problem, comment out the code.
+If you haven't deployed the uncommented code it might be best to prepare that before the demonstration. After pointing out the problem, comment out the code.
 
 [![](/images/industrial-edge/commented-code.png)](/images/industrial-edge/commented-code.png)
 
@@ -130,18 +130,18 @@ make build-and-test
 
 This build takes some time because the pipeline is rebuilding all the images. You can monitor the pipeline's progress in the Openshift console's pipelines section.
 
-Alternatively you can can try and run the shorter `build-iot-consumer` pipeline run in the OpenShift console. This should just run and test the specific application.  
+Alternatively you can can try and run the shorter `build-iot-consumer` pipeline run in the OpenShift console. This should just run and test the specific application.
 
 [![](/images/industrial-edge/build-and-test-pipeline.png)](/images/industrial-edge/build-and-test-pipeline.png)
 
 You can also see some updates happening in the `manuela-tst` application in OpenShift GitOps (ArgoCD).
 
-When the pipeline is complete check the `lines-dashboard` application again in the browser. More reasonable, Celsius, tempratures are displayed. (Compare with above.)
+When the pipeline is complete check the `lines-dashboard` application again in the browser. More reasonable, Celsius, temperatures are displayed. (Compare with above.)
 
 [![](/images/industrial-edge/celsius-temp.png)](/images/industrial-edge/celsius-temp.png)
 
 
-The steps above have successfully applied the change to the Manuela test environment at the data center. In order for these changes to be pushed out to the factories it must be accepted and pushed to the Git repository. Examine the project in GitHub. There is a new Pull Request (PR) called **Pull request created by Tekton task github-add-pull-request**. Select that PR and merge the pull request.  
+The steps above have successfully applied the change to the Manuela test environment at the data center. In order for these changes to be pushed out to the factories it must be accepted and pushed to the Git repository. Examine the project in GitHub. There is a new Pull Request (PR) called **Pull request created by Tekton task github-add-pull-request**. Select that PR and merge the pull request.
 
 [![](/images/industrial-edge/tekton-pull-request.png)](/images/industrial-edge/tekton-pull-request.png)
 
@@ -154,7 +154,7 @@ After a successful deployment of Industrial Edge 2.0, check to see that Jupyter 
 
 [![](/images/industrial-edge/jupyterhub-pods.png)](/images/industrial-edge/jupyterhub-pods.png)
 
-Then, in the same project `manuela-ml-namespace`, select Networking/Routes and click on the URL associated with `jupyterhub` in the Locationo column.
+Then, in the same project `manuela-ml-namespace`, select Networking/Routes and click on the URL associated with `jupyterhub` in the Location column.
 
 [![](/images/industrial-edge/jupyterhub-url.png)](/images/industrial-edge/jupyterhub-url.png)
 

--- a/industrial-edge/cluster-sizing.md
+++ b/industrial-edge/cluster-sizing.md
@@ -54,7 +54,7 @@ Here's an inventory of what gets deployed by the **Industrial-Edge** pattern on 
 | Red Hat OpenShift GitOps | Operator | openshift-operators | OpenShift GitOps
 | Red Hat Integration - Camel K | Operator | manuela-tst-all | Integration Platform, Kamelet Binding, Kamelet
 | Red Hat OpenShift Pipelines | Operator | All Namespaces | Tekton Config, Pipelines, Triggers, Addons
-| Seldon Operator | Operator | manuela-tst-all | Seldon Delpoyment
+| Seldon Operator | Operator | manuela-tst-all | Seldon Deployment
 
 
 ### Industrial-Edge Pattern OpenShift Datacenter HUB Cluster Size

--- a/industrial-edge/factory.md
+++ b/industrial-edge/factory.md
@@ -6,7 +6,7 @@ parent: Industrial Edge
 nav_order: 2
 ---
 
-# Having a factory (edge) cluster join the datacenter (hub) 
+# Having a factory (edge) cluster join the datacenter (hub)
 {: .no_toc }
 
 ## Table of contents
@@ -63,7 +63,7 @@ There are a three ways to join the factory to the datacenter.
 
 ![](/images/launch-acm-console.png "Launch ACM console")
 
-2. Select the "Import cluster" option beside the highleded Create Cluster button.
+2. Select the "Import cluster" option beside the highlighted Create Cluster button.
 
 ![](/images/import-cluster.png "Select Import cluster")
 
@@ -71,7 +71,7 @@ There are a three ways to join the factory to the datacenter.
 
 ![](/images/import-with-kubeconfig.png "Import using kubeconfig")
 
-Using this menthod, you are done. Skip to the section [Factory is joined](#factory-is-joined) but ignore the part about adding the site tag.
+Using this method, you are done. Skip to the section [Factory is joined](#factory-is-joined) but ignore the part about adding the site tag.
 
 ## Factory setup using `cm` tool
 
@@ -84,13 +84,13 @@ Using this menthod, you are done. Skip to the section [Factory is joined](#facto
 1. Run the following command:
 ```sh
 cm attach cluster --cluster <cluster-name> --cluster-kubeconfig <path-to-KUBECONFIG>
-``` 
+```
 
 Skip to the section [Factory is joined](#factory-is-joined)
 
 ## Factory setup using `clusteradm` tool
 
-You can also use `clusteradm` to join a cluster. The folloing instructions explain what needs to be done. `clusteradm` is still in testing.
+You can also use `clusteradm` to join a cluster. The following instructions explain what needs to be done. `clusteradm` is still in testing.
 
 1. To deploy a edge cluster you will need to get the datacenter (or hub) cluster's token. You will need to install `clusteradm`.  On the existing *datacenter cluster*:
 
@@ -100,14 +100,14 @@ You can also use `clusteradm` to join a cluster. The folloing instructions expla
 
    `oc login`
    or
-   
+
    `export KUBECONFIG=~/my-ocp-env/factory`
 
 1. Then request to that the factory join the datacenter hub
 
    `clusteradm join --hub-token <token from clusteradm get token command > <factory cluster name>`
 
-1. Back on the hub cluster accept the join reguest 
+1. Back on the hub cluster accept the join request
 
    `clusteradm accept --clusters <factory-cluster-name>`
 
@@ -117,7 +117,7 @@ Skip to the next section, [Factory is joined](#factory-is-joined)
 
 ### Designate the new cluster as a factory site
 
-Now that ACM is no longer deploying the factory applications everywhere, we need 
+Now that ACM is no longer deploying the factory applications everywhere, we need
 to explicitly indicate that the new cluster has the factory role. If you haven't tagged the cluster as `site=managed-cluster` then we can that here.
 
 We do this by adding the label referenced in the managedSite's `clusterSelector`.
@@ -131,7 +131,7 @@ We do this by adding the label referenced in the managedSite's `clusterSelector`
    `oc label managedclusters.cluster.open-cluster-management.io/YOURCLUSTER site=factory`
 
 ### You're done
-That's it! Go to your factory (edge) OpenShift console and check for the open-cluster-management-agent pod being launched. Be patient, it will take a while for the ACM agent and agent-addons to launch. After that, the operator OpenShifdt GitOps will run. When it's finished coming up launch the OpenShift GitOps (ArgoCD) console from the top right of the OpenShift console. 
+That's it! Go to your factory (edge) OpenShift console and check for the open-cluster-management-agent pod being launched. Be patient, it will take a while for the ACM agent and agent-addons to launch. After that, the operator OpenShift GitOps will run. When it's finished coming up launch the OpenShift GitOps (ArgoCD) console from the top right of the OpenShift console.
 
 ## Next up
 

--- a/industrial-edge/getting-started.md
+++ b/industrial-edge/getting-started.md
@@ -31,7 +31,7 @@ nav_order: 1
 
 The use of this blueprint depends on having at least one running Red Hat
 OpenShift cluster. It is desirable to have a cluster for deploying the data
-center assets and a seperate cluster(s) for the factory assets.
+center assets and a separate cluster(s) for the factory assets.
 
 If you do not have a running Red Hat OpenShift cluster you can start one on a
 public or private cloud by using [Red Hat's cloud

--- a/industrial-edge/index.md
+++ b/industrial-edge/index.md
@@ -28,7 +28,7 @@ nav_order: 2
 With this Pattern, we demonstrate a horizontal solution for Industrial Edge use cases.
 
 It is derived from the [MANUela work](https://github.com/sa-mw-dach/manuela) done by Red
-Hat Middleware Solution Architects in Germany in 2019/20. The name MANUela stands for MANUfacturing Edge Lightweight Accelerator, you will see this acronym in a lot of artefacts. It was developed on a platform called [stormshift](https://github.com/stormshift/documentation) - another name you will see here and there.
+Hat Middleware Solution Architects in Germany in 2019/20. The name MANUela stands for MANUfacturing Edge Lightweight Accelerator, you will see this acronym in a lot of artifacts. It was developed on a platform called [stormshift](https://github.com/stormshift/documentation) - another name you will see here and there.
 
 The demo has been updated 2021 with an advanced GitOps framework.
 
@@ -45,8 +45,8 @@ industrial setting, using AI/ML. It could be easily extended to other use cases,
 
 ### Red Hat Technologies
 
-- Red Hat OpenShift Container Platform (Kubernetes++)
-- Red Hat Advanced Cluster Management (Open Clutser Management)
+- Red Hat OpenShift Container Platform (Kubernetes)
+- Red Hat Advanced Cluster Management (Open Cluster Management)
 - Red Hat OpenShift GitOps (ArgoCD)
 - Red Hat OpenShift Pipelines (Tekton)
 - Red Hat Quay (Container image registry)
@@ -67,7 +67,7 @@ With Industrial Edge computing, it’s all about two major streams:
 The Industrial Edge Validated Pattern / Demo Scenario reflects this by having 3 layers:
 - Line Data Server - the far edge, at the shop floor level
 - Factory Data Center - the near edge, at the plant, but in a more controlled environment.
-- Central Data Ceneter - the cloud/core, where ML Model Training, AppDev, Testing etc. is happening (and ERP systems of course, not part of the demo).
+- Central Data Center - the cloud/core, where ML Model Training, AppDev, Testing etc. is happening (and ERP systems of course, not part of the demo).
 [![Demo Scenario](/images/industrial-edge/highleveldemodiagram.png)](/images/industrial-edge/highleveldemodiagram.png)
 
 The northbound traffic of sensor data is clearly visible in this diagram: from the Sensor at the bottom via MQTT to the Factory, where it is split into two streams: one to be fed into a ML Model for anomaly detection, an another one to be streamed up to the central data center via event streaming (Kafka) to be stored for model training.
@@ -83,7 +83,7 @@ The following diagram explains how different roles have different concerns and f
 In the Industrial Edge architecture there are two logical types of sites.
 
 - The datacenter. This is where the data scientist, developers and operations personnel apply the changes to their models, application code and configurations.
-- The factories. This is where new applications, updates and operational changes are deployed to improve quality and efficency in the factory.
+- The factories. This is where new applications, updates and operational changes are deployed to improve quality and efficiency in the factory.
 
 For logical, physical and dataflow diagrams, please see excellent work done by the [Red Hat Portfolio Architecture team](https://gitlab.com/redhatdemocentral/portfolio-architecture-examples/-/blob/main/manufacturing.adoc)
 

--- a/industrial-edge/troubleshooting.md
+++ b/industrial-edge/troubleshooting.md
@@ -130,7 +130,7 @@ We're looking into better long-term fixes for a number of the situations that ca
 
 **Cause:** Multiple processes or people were trying to make changes to the repo at the same time.  The state of the repo changed in the middle of the process in such a way that the update was not a "fast-forward" in git terms.
 
-**Resolution:** Re-run the failed pipeline segement OR run `make seed` from the root of your fork of the industrial-edge repo.
+**Resolution:** Re-run the failed pipeline segment OR run `make seed` from the root of your fork of the industrial-edge repo.
 
 It is also possible that multiple pipelines were running at the same time and were making conflicting changes. We recommend running one pipeline at a time.
 

--- a/medical-diagnosis/cluster-sizing.md
+++ b/medical-diagnosis/cluster-sizing.md
@@ -54,7 +54,7 @@ The Datacenter HUB OpenShift Cluster is made up of the the following on the AWS 
 | Control Plane | 3 | Amazon Web Services | m5.xlarge
 | Worker | 5 | Amazon Web Services | m5.4xlarge
 
-The Datacenter HUB OpenShift cluster needs to be a bit bigger than the edge based medical facilities clusters because this is where the developers will be running pipelines to build and deploy the **Medical Diagnosis** pattern on the cluster. The pattern on the data center also requires extra storageand computet o handle the large number of images to be processed. The above cluster sizing is close to a **minimum** size for a Datacenter HUB cluster.  In the next few sections we take some snapshots of the cluster utilization while the **Medical Diagnosis** pattern is running.  Keep in mind that resources will have to be added as more developers are working building their applications. 
+The Datacenter HUB OpenShift cluster needs to be a bit bigger than the edge based medical facilities clusters because this is where the developers will be running pipelines to build and deploy the **Medical Diagnosis** pattern on the cluster. The pattern on the data center also requires extra storage and compute to handle the large number of images to be processed. The above cluster sizing is close to a **minimum** size for a Datacenter HUB cluster.  In the next few sections we take some snapshots of the cluster utilization while the **Medical Diagnosis** pattern is running.  Keep in mind that resources will have to be added as more developers are working building their applications. 
 
 #### Datacenter Cluster utilization 
 Below is a snapshot of the OpenShift cluster utilization while running the **Medical Diagnosis** pattern: 

--- a/medical-diagnosis/getting-started.md
+++ b/medical-diagnosis/getting-started.md
@@ -6,7 +6,7 @@ parent: Medical Diagnosis
 nav_order: 1
 ---
 
-# Deploying the Medical Diagnosis pattern  
+# Deploying the Medical Diagnosis pattern
 {: .no_toc }
 
 ## Table of contents
@@ -22,7 +22,7 @@ nav_order: 1
 1. Storage set up in your public/private cloud for the x-ray images
 1. The helm binary, see https://helm.sh/docs/intro/install/
 
-The use of this blueprint depends on having at least one running Red Hat OpenShift cluster. It is desirable to have a cluster for deploying the GitOps management hub assets and a seperate cluster(s) for the medical egde facilities.
+The use of this blueprint depends on having at least one running Red Hat OpenShift cluster. It is desirable to have a cluster for deploying the GitOps management hub assets and a separate cluster(s) for the medical edge facilities.
 
 If you do not have a running Red Hat OpenShift cluster you can start one on a
 public or private cloud by using [Red Hat's cloud
@@ -30,12 +30,12 @@ service](https://console.redhat.com/openshift/create).
 
 ## Setting up the storage for OpenShift Data Foundation
 
-Red Hat OpenShift Data Foundation relies on underlying object based storage provided by cloud providers. This storage will need to be public. The following links provide information on how to create the cloud storage required for this validated pattern on several cloud providers. 
+Red Hat OpenShift Data Foundation relies on underlying object based storage provided by cloud providers. This storage will need to be public. The following links provide information on how to create the cloud storage required for this validated pattern on several cloud providers.
 * [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/creating-bucket.html)
-* [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal) 
+* [Azure Blob Storage](https://docs.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal)
 * [GCP Cloud Storage](https://cloud.google.com/storage/docs/quickstart-console)
 
-There are some utilities that have been created for the validated patterns effort to speed the process. 
+There are some utilities that have been created for the validated patterns effort to speed the process.
 
 If you are using the utilities then you first you need to set some environment variables for your cloud provider keys.
 
@@ -45,7 +45,7 @@ export AWS_ACCESS_KEY_ID=AKXXXXXXXXXXXXX
 export AWS_SECRET_ACCESS_KEY=gkXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
-Then we need to create the S3 bucket and copy over the data from the validated patterns public bucket to the created bucket for your demo. You can do this on the cloud providers console or use the scripts provided on `validated-patterns-utilities` repo.  
+Then we need to create the S3 bucket and copy over the data from the validated patterns public bucket to the created bucket for your demo. You can do this on the cloud providers console or use the scripts provided on `validated-patterns-utilities` repo.
 
 ```
 python s3-create.py -b mytest-bucket -r us-west-2 -p
@@ -56,7 +56,7 @@ The output should look similar to this edited/compressed output.
 
 ![Bucket setup](/videos/bucket-setup.svg)]
 
-There is some key information you will need to take note of that is required by the 'values-global.yaml' file. You will need the URL for the buckeyt and it's name. At the very end of the `values-global.yaml` file you will see a section for `s3:` were these values need to be changed.
+There is some key information you will need to take note of that is required by the 'values-global.yaml' file. You will need the URL for the bucket and it's name. At the very end of the `values-global.yaml` file you will see a section for `s3:` were these values need to be changed.
 
 # Preparation
 
@@ -77,9 +77,9 @@ There is some key information you will need to take note of that is required by 
    cp values-secret.yaml.template ~/values-secret.yaml
    vi ~/values-secret.yaml
    ```
-   When you edit the file you can make changes to the various DB passwords if you wish. 
+   When you edit the file you can make changes to the various DB passwords if you wish.
 
-1. Customize the deployment for your cluster. Remember to use the data optained from the cloud storage creation (S3, Blob Storage, Cloud Storage) as part of the data to be updated in the yaml file. There are comments in the file highlightiung what what chnages need to be made.
+1. Customize the deployment for your cluster. Remember to use the data obtained from the cloud storage creation (S3, Blob Storage, Cloud Storage) as part of the data to be updated in the yaml file. There are comments in the file highlighting what what changes need to be made.
 
    ```sh
    vi values-global.yaml
@@ -106,11 +106,11 @@ There is some key information you will need to take note of that is required by 
    ```sh
    export KUBECONFIG=~/my-ocp-env/auth/kubconfig
    ```
-   
+
 ## Check the values files before deployment
 
-You can run a check before deployment to make sure that you have the required variables to deploy the 
-Medical Diagnosis Validated Pattern.  
+You can run a check before deployment to make sure that you have the required variables to deploy the
+Medical Diagnosis Validated Pattern.
 
 You can run `make predeploy` to check your values. This will allow you to review your values and changed them in
 the case there are typos or old values.  The values files that should be reviewed prior to deploying the
@@ -122,7 +122,7 @@ Medical Diagnosis Validated Pattern are:
 | values-global.yaml | File that is used to contain all the global values used by Helm |
 
 Make sure you have the correct domain, clustername, externalUrl, targetBucket and bucketSource values.
- 
+
 [![asciicast](https://github.com/claudiol/medical-diagnosis/blob/claudiol-xray-deployment/doc/predeploy.svg)](https://github.com/claudiol/medical-diagnosis/blob/claudiol-xray-deployment/doc/predeploy.svg)
 
 # Deploy
@@ -135,7 +135,7 @@ Make sure you have the correct domain, clustername, externalUrl, targetBucket an
 
    If the install fails and you go back over the instructions and see what was missed and change it, then run `make update` to continue the installation.
 
-1. This takes some time. Especially for the OpenShift Data Foundation operator components to install and synchronize. The `make install` provides some progress updates during the install. It can take up to twentry minutes. Compare your `make install` run progress with the following video showing a successful install. 
+1. This takes some time. Especially for the OpenShift Data Foundation operator components to install and synchronize. The `make install` provides some progress updates during the install. It can take up to twenty minutes. Compare your `make install` run progress with the following video showing a successful install.
 
    [![Demo](/videos/xray-deployment.svg)](/videos/xray-deployment.svg)
 
@@ -147,9 +147,9 @@ Make sure you have the correct domain, clustername, externalUrl, targetBucket an
    The main operator to watch is the OpenShift Data Foundation.
 
 ## Using OpenShift GitOps to check on Application progress
-You can also check on the progress using OpenShift GitOps to check on the various applications deployed. 
+You can also check on the progress using OpenShift GitOps to check on the various applications deployed.
 
-1. Obtain the ArgoCD urls and passwords. 
+1. Obtain the ArgoCD urls and passwords.
 
    The URLs and login credentials for ArgoCD change depending on the pattern
    name and the site names they control.  Follow the instructions below to find
@@ -187,7 +187,7 @@ You can also check on the progress using OpenShift GitOps to check on the variou
 
 ## Viewing the Grafana based dashboard.
 
-1. First we need to accept SSL certificates on the browser for the dashboard. In the OpenShift console go to the Routes for project openshift-storage. Click on the URL for the s3-rgw. 
+1. First we need to accept SSL certificates on the browser for the dashboard. In the OpenShift console go to the Routes for project openshift-storage. Click on the URL for the s3-rgw.
 
    [![Storage Routes](/images/medical-edge/storage-route.png)](/images/medical-edge/storage-route.png))
 
@@ -201,7 +201,7 @@ You can also check on the progress using OpenShift GitOps to check on the variou
 
 1. Turn on the image file flow. There are three ways to go about this.
 
-   You can go to the command line (maje sure you have KUBECONFIG set, or are logged into the cluster. 
+   You can go to the command line (make sure you have KUBECONFIG set, or are logged into the cluster.
 
    ```
    oc scale deploymentconfig/image-generator --replicas=1
@@ -211,11 +211,11 @@ You can also check on the progress using OpenShift GitOps to check on the variou
 
    [![Xraylab-1 Topology](/images/medical-edge/dev-topology.png)](/images/medical-edge/dev-topology.png))
 
-   Right click on the `image-generator` pod icon and select `Edit Pod count`. 
+   Right click on the `image-generator` pod icon and select `Edit Pod count`.
 
    [![Pod menu](/images/medical-edge/dev-topology-menu.png)](/images/medical-edge/dev-topology-menu.png))
- 
-   Up the pod count from `0` to `1` and save.  
+
+   Up the pod count from `0` to `1` and save.
 
    [![Pod count](/images/medical-edge/dev-topology-pod-count.png)](/images/medical-edge/dev-topology-pod-count.png))
 
@@ -242,7 +242,7 @@ You can change some of the parameters and watch how the changes effect the dashb
    oc scale deploymentconfig/image-generator --replicas=0
    ```
 
-   Watch the dashboard stop processing images. 
+   Watch the dashboard stop processing images.
 
 1. You can also simulate the change of the AI model version - as it's only an environment variable in the Serverless Service configuration.
 

--- a/medical-diagnosis/index.md
+++ b/medical-diagnosis/index.md
@@ -24,7 +24,7 @@ nav_order: 3
 {:toc}
 
 ## Background
-This Validated Pattern is based on a demo implemetation of an automated data pipeline for chest Xray
+This Validated Pattern is based on a demo implementation of an automated data pipeline for chest Xray
 analysis previously developed by Red Hat.  The original demo can be found [here](https://github.com/red-hat-data-services/jumpstart-library). It was developed for the US Department of Veteran Affairs.
 
 This validated pattern includes the same functionality as the original demonstration. The difference is
@@ -55,8 +55,8 @@ please contact [Jonny Rickard](jrickard@redhat.com) or [Lester Claudio](claudiol
 
 ### Red Hat Technologies
 
-- Red Hat OpenShift Container Platform (Kubernetes++)
-- Red Hat Advanced Cluster Management (Open Clutser Management)
+- Red Hat OpenShift Container Platform (Kubernetes)
+- Red Hat Advanced Cluster Management (Open Cluster Management)
 - Red Hat OpenShift GitOps (ArgoCD)
 - Red Hat Quay (Container image registry)
 - Red Hat AMQ Streams (Apache Kafka Event Broker)
@@ -75,7 +75,7 @@ Components are running on OpenShift either at the data center or at the medical 
 
 In the Medical Diagnosis architecture there are two logical sites.
 
-- The Management Hub. This is where the multiple managed clusters deployed on clouds (public or private) are managed. Application and configuration code is workied on here and deployed to the other managed clusters. There is one management hub.
+- The Management Hub. This is where the multiple managed clusters deployed on clouds (public or private) are managed. Application and configuration code is worked on here and deployed to the other managed clusters. There is one management hub.
 - The Managed Cluster. This is where new applications, updates and operational changes are deployed for the business. There are more than one managed clusters.
 
 [![Multi-Cloud Logical Architecture](/images/medical-edge/logical-diagram.png)](/images/medical-edge/logical-diagram.png)

--- a/multicloud-gitops/getting-started.md
+++ b/multicloud-gitops/getting-started.md
@@ -18,13 +18,13 @@ nav_order: 1
 # Prerequisites
 
 1. An OpenShift cluster ( Go to https://console.redhat.com/openshift/create ). See also [sizing your cluster](../cluster-sizing).
-1. (Optional) A second OpenShift cluster for mulitcloud demonstration or testing
+1. (Optional) A second OpenShift cluster for multicloud demonstration or testing
 1. A github account (and a token for it with repos permissions, to read from and write to your forks)
 1. The helm binary, see https://helm.sh/docs/intro/install/
 
 The use of this blueprint depends on having at least one running Red Hat
 OpenShift cluster. It is desirable to have a cluster for deploying the GitOps 
-management hub assets and a seperate cluster(s) for the managed cluster(s).
+management hub assets and a separate cluster(s) for the managed cluster(s).
 
 If you do not have a running Red Hat OpenShift cluster you can start one on a
 public or private cloud by using [Red Hat's cloud

--- a/multicloud-gitops/index.md
+++ b/multicloud-gitops/index.md
@@ -24,23 +24,22 @@ nav_order: 1
 {:toc}
 
 ## Background
-Organizations are looking for a way to develop and deploy applications on open hybrid cloud in a stable, simple, and secure way. This hybrid approach includes multi-cloud deployments where workloads may be running on different clusters on different clouds - private or public. This also requires an infrastructutre-as-code approach that manages versions and being able to deploy based on specific deloyment configurations. 
+Organizations are looking for a way to develop and deploy applications on open hybrid cloud in a stable, simple, and secure way. This hybrid approach includes multi-cloud deployments where workloads may be running on different clusters on different clouds - private or public. This also requires an infrastructure-as-code approach that manages versions and being able to deploy based on specific deployment configurations.
 
 The pattern is derived from work done by the [Red Hat Portfolio Architecture team](https://gitlab.com/redhatdemocentral/portfolio-architecture-examples/-/blob/main/spi-multi-cloud-gitops.adoc)
 
 ### Solution elements
 
-- How to use a GitOps approach to manage multiple cloud dpeloyments in both public and private clouds.
+- How to use a GitOps approach to manage multiple cloud deployments in both public and private clouds.
 - How to centrally manage multiple clusters, including workloads.
 - How to securely manage secrets across multi-cloud deployments.
 
 ### Red Hat Technologies
 
-- Red Hat OpenShift Container Platform (Kubernetes++)
-- Red Hat Advanced Cluster Management (Open Clutser Management)
+- Red Hat OpenShift Container Platform (Kubernetes)
+- Red Hat Advanced Cluster Management (Open Cluster Management)
 - Red Hat OpenShift GitOps (ArgoCD)
-- Hasicorp Vault
-- [TBD]
+- Hashicorp Vault
 
 ## Architecture
 At a high level this requires a management hub, for DevOps and GitOps, and and infrastructure that extends to more than one managed clusters running on private or public clouds.

--- a/multicloud-gitops/managed-cluster.md
+++ b/multicloud-gitops/managed-cluster.md
@@ -6,7 +6,7 @@ parent: Multicloud GitOps
 nav_order: 2
 ---
 
-# Having a managed cluster (edge) join the management hub 
+# Having a managed cluster (edge) join the management hub
 {: .no_toc }
 
 ## Table of contents
@@ -17,7 +17,7 @@ nav_order: 2
 
 ## Allow ACM to deploy the managed cluster application to a subset of clusters
 
-By default the `clusterGroup` applications are deployed on all clusters that ACM knows about. In you `value-hub.yaml` file add a `managedClusterCgroup` for each cluster or group of clusters that you want to manage was one. 
+By default the `clusterGroup` applications are deployed on all clusters that ACM knows about. In you `value-hub.yaml` file add a `managedClusterCgroup` for each cluster or group of clusters that you want to manage was one.
 
 ```yaml
   managedClusterGroups:
@@ -31,7 +31,7 @@ By default the `clusterGroup` applications are deployed on all clusters that ACM
 ```
 
 The above yaml segment will deploy the `clusterGroup` applications on managed clusters with the label
-`clusterGroup=region-one`.  Specific subscriptions and Operators, applications and projects for that `clusterGroup` are then managed in a `value-region-one.yaml` file. E.g. 
+`clusterGroup=region-one`.  Specific subscriptions and Operators, applications and projects for that `clusterGroup` are then managed in a `value-region-one.yaml` file. E.g.
 
 ```yaml
   namespaces:
@@ -74,7 +74,7 @@ There are a three ways to join the managed cluster to the management hub.
 
 ![](/images/launch-acm-console.png "Launch ACM console")
 
-2. Select the "Import cluster" option beside the highleded Create Cluster button.
+2. Select the "Import cluster" option beside the highlighted Create Cluster button.
 
 ![](/images/import-cluster.png "Select Import cluster")
 
@@ -82,7 +82,7 @@ There are a three ways to join the managed cluster to the management hub.
 
 ![](/images/import-with-kubeconfig.png "Import using kubeconfig")
 
-Using this menthod, you are done. Skip to the section [Managed cluster is joined](#managed-cluster-is-joined) but ignore the part about adding the site tag.
+Using this method, you are done. Skip to the section [Managed cluster is joined](#managed-cluster-is-joined) but ignore the part about adding the site tag.
 
 ## Managed cluster setup using `cm` tool
 
@@ -95,13 +95,13 @@ Using this menthod, you are done. Skip to the section [Managed cluster is joined
 1. Run the following command:
 ```sh
 cm attach cluster --cluster <cluster-name> --cluster-kubeconfig <path-to-KUBECONFIG>
-``` 
+```
 
 Skip to the section [Managed cluster is joined](#managed-cluster-is-joined)
 
 ## Managed cluster setup using `clusteradm` tool
 
-You can also use `clusteradm` to join a cluster. The folloing instructions explain what needs to be done. `clusteradm` is still in testing.
+You can also use `clusteradm` to join a cluster. The following instructions explain what needs to be done. `clusteradm` is still in testing.
 
 1. To deploy a edge cluster you will need to get the management hub cluster's token. You will need to install `clusteradm`.  On the existing *management hub cluster*:
 
@@ -111,14 +111,14 @@ You can also use `clusteradm` to join a cluster. The folloing instructions expla
 
    `oc login`
    or
-   
+
    `export KUBECONFIG=~/my-ocp-env/managed-cluster`
 
 1. Then request to that the managed cluster join the management hub
 
    `clusteradm join --hub-token <token from clusteradm get token command > <managed cluster name>`
 
-1. Back on the hub cluster accept the join reguest 
+1. Back on the hub cluster accept the join request
 
    `clusteradm accept --clusters <managed-cluster-name>`
 
@@ -128,7 +128,7 @@ Skip to the section [Managed cluster is joined](#managed-cluster-is-joined)
 
 ### Designate the new cluster as a managed cluster site
 
-Now that ACM is no longer deploying the managed cluster applications everywhere, we need 
+Now that ACM is no longer deploying the managed cluster applications everywhere, we need
 to explicitly indicate that the new cluster has the managed cluster role. **If you haven't tagged the cluster** as `clusterGroup=region-one` then we can that here.
 
 We do this by adding the label referenced in the managedSite's `clusterSelector`.
@@ -142,4 +142,4 @@ We do this by adding the label referenced in the managedSite's `clusterSelector`
    `oc label region-one.cluster.open-cluster-management.io/YOURCLUSTER site=managed-cluster`
 
 ### You're done
-That's it! Go to your managed cluster (edge) OpenShift console and check for the open-cluster-management-agent pod being launched. Be patient, it will take a while for the ACM agent and agent-addons to launch. After that, the operator OpenShifdt GitOps will run. When it's finished coming up launch the OpenShift GitOps (ArgoCD) console from the top right of the OpenShift console. 
+That's it! Go to your managed cluster (edge) OpenShift console and check for the open-cluster-management-agent pod being launched. Be patient, it will take a while for the ACM agent and agent-addons to launch. After that, the operator OpenShift GitOps will run. When it's finished coming up launch the OpenShift GitOps (ArgoCD) console from the top right of the OpenShift console.

--- a/secrets.md
+++ b/secrets.md
@@ -29,9 +29,9 @@ One area that has been impacted by a more automated approach to security is in t
 1. Image repositories
 1. Build pipelines
 
-All of these services require credentials. (Or should do!) And keeping those credentials secret is very important. E.g. pushing your crententials to your personal GitHub/GitLab repository is not a secure solution.
+All of these services require credentials. (Or should do!) And keeping those credentials secret is very important. E.g. pushing your credentials to your personal GitHub/GitLab repository is not a secure solution.
 
-While using a file based secret management can work if done correctly, most organizations opt for a more enterprise soutiono using a secret management product or project. The Cloud Native Computing Foundation (CNCF) has many such [projects](https://radar.cncf.io/2021-02-secrets-management). The Hybrid Cloud Patterns project has started with Hashicorp Vault secret management product but we look forward to other project contributions.
+While using a file based secret management can work if done correctly, most organizations opt for a more enterprise solution using a secret management product or project. The Cloud Native Computing Foundation (CNCF) has many such [projects](https://radar.cncf.io/2021-02-secrets-management). The Hybrid Cloud Patterns project has started with Hashicorp Vault secret management product but we look forward to other project contributions.
 
 ## What's next?
 [Getting started with Vault](secrets/vault.md)

--- a/workflow.md
+++ b/workflow.md
@@ -7,7 +7,7 @@ nav_order: 4
 # Workflow
 
 These patterns are designed to be composed of multiple components, and for those components to be used in gitops
-workflows by consumers and contributors.  To use the first pattern as an example, we maintain the [Industrial Edge](industrial-edge) pattern, which uses a [repo](https://github.com/hybrid-cloud-patterns/industrial-edge) with pattern-specific logic and configuration as well as a [common repo](https://github.com/hybrid-cloud-patterns/common) which has elements common to multiple patterns.  The common repo is included in each pattern repo as a subtree; t
+workflows by consumers and contributors.  To use the first pattern as an example, we maintain the [Industrial Edge](industrial-edge) pattern, which uses a [repo](https://github.com/hybrid-cloud-patterns/industrial-edge) with pattern-specific logic and configuration as well as a [common repo](https://github.com/hybrid-cloud-patterns/common) which has elements common to multiple patterns.  The common repo is included in each pattern repo as a subtree.
 
 ## Consuming a pattern 
 


### PR DESCRIPTION
This review does just two things:
1. A quick 'find . -type f -exec aspell -c "{}" \;'
2. Remove extraneous spaces at end of lines
