### PR TITLE
Fix jekyll issuess from post

### DIFF
--- a/_posts/2022-03-23-acm-mustonlyhave.md
+++ b/_posts/2022-03-23-acm-mustonlyhave.md
@@ -56,6 +56,7 @@ That list under the `valueFiles` attribute was wrong. It still contained referen
 
 The problem turned out to be in how we pushed out the ArgoCD Application via ACM. We did this:
 
+{% raw %}
 ```sh
 apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
@@ -106,6 +107,7 @@ spec:
                         value: $ARGOCD_APP_SOURCE_REPO_URL
 ...
 ```
+{% endraw %}
 
 The problem was entirely into the `complianceType: musthave`. Quoting the docs at <https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.4/html-single/governance/index#configuration-policy-yaml-table> we have three possibilities:
 


### PR DESCRIPTION
Jekyll (github pages engine) was complaining about the blog post. It get's messed up by special characters which the post has in some kube yaml snipplet. I made them skip the pre-processor.

Warnings before:
```
    Liquid Warning: Liquid syntax error (line 3): Expected dotdot but found id in "(page.header.overlay_color or page.header.overlay_image) or page.header.image" in /_layouts/post.html
    Liquid Warning: Liquid syntax error (line 53): [:dot, "."] is not a valid expression in "{{ .name }}" in /srv/jekyll/_posts/2022-03-23-acm-mustonlyhave.md
    Liquid Warning: Liquid syntax error (line 65): [:dot, "."] is not a valid expression in "{{ .name }}" in /srv/jekyll/_posts/2022-03-23-acm-mustonlyhave.md
    Liquid Warning: Liquid syntax error (line 80): Unexpected character $ in "{{ $.Values.global.pattern }}" in /srv/jekyll/_posts/2022-03-23-acm-mustonlyhave.md
    Liquid Warning: Liquid syntax error (line 80): [:dot, "."] is not a valid expression in "{{ .name }}" in /srv/jekyll/_posts/2022-03-23-acm-mustonlyhave.md
    Liquid Warning: Liquid syntax error (line 87): Unexpected character $ in "{{ coalesce .repoURL $.Values.global.repoURL }}" in /srv/jekyll/_posts/2022-03-23-acm-mustonlyhave.md
    Liquid Warning: Liquid syntax error (line 88): Unexpected character $ in "{{ coalesce .targetRevision $.Values.global.targetRevision }}" in /srv/jekyll/_posts/2022-03-23-acm-mustonlyhave.md
    Liquid Warning: Liquid syntax error (line 89): Expected end_of_string but found string in "{{ default "common/clustergroup" .path }}" in /srv/jekyll/_posts/2022-03-23-acm-mustonlyhave.md
    Liquid Warning: Liquid syntax error (line 92): Unexpected character $ in "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}" in /srv/jekyll/_posts/2022-03-23-acm-mustonlyhave.md
    Liquid Warning: Liquid syntax error (line 93): Unexpected character $ in "{{ coalesce .valuesDirectoryURL $.Values.global.valuesDirectoryURL }}" in /srv/jekyll/_posts/2022-03-23-acm-mustonlyhave.md
    Liquid Warning: Liquid syntax error (line 93): [:dot, "."] is not a valid expression in "{{ .name }}" in /srv/jekyll/_posts/2022-03-23-acm-mustonlyhave.md
    Liquid Warning: Liquid syntax error (line 3): Expected dotdot but found id in "(page.header.overlay_color or page.header.overlay_image) or page.header.image" in /_layouts/post.html
    Liquid Warning: Liquid syntax error (line 3): Expected dotdot but found id in "(page.header.overlay_color or page.header.overlay_image) or page.header.image" in /_layouts/post.html
j
```

After just the usual template warnings:

```
    Liquid Warning: Liquid syntax error (line 3): Expected dotdot but found id in "(page.header.overlay_color or page.header.overlay_image) or page.header.image" in /_layouts/post.html
    Liquid Warning: Liquid syntax error (line 3): Expected dotdot but found id in "(page.header.overlay_color or page.header.overlay_image) or page.header.image" in /_layouts/post.html
    Liquid Warning: Liquid syntax error (line 3): Expected dotdot but found id in "(page.header.overlay_color or page.header.overlay_image) or page.header.image" in /_layouts/post.html
```
