### PR TITLE
Fix jekyll to listen to any interface so it works in container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
 serve:
-	@echo "Next run:        ssh -L4000:localhost:4000 `uname -n`"
-	@echo "And browse to:  http://localhost:4000"
-	jekyll serve -w --trace --config _config.yml,_local.yml
+	@echo "Next browse to:  http://localhost:4000"
+	jekyll serve -w --trace --config _config.yml,_local.yml --host 0.0.0.0


### PR DESCRIPTION
currently the web pages won't work without podman ```--net host``` option. I was wondering why is that. It seems that by default the jekyll listens to localhost, 127.0.0.1, and thus doesn't get the incoming traffic. I changed the makefile so it listens to any interface. Now it works as proper container without the host networking.

I wanted to fix this as I spent some time troubleshooting jekyll for this reason. Should not break anything if run outside of container either. I also removed the ssh line, as I don't see any need for it. 