### PR TITLE
Clean target + typo fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,6 @@ htmlproof:
 lintwordlist:
 	@sort .wordlist.txt | tr '[:upper:]' '[:lower:]' | uniq > /tmp/.wordlist.txt
 	@mv -v /tmp/.wordlist.txt .wordlist.txt
+
+clean:
+	@rm -rvf ./.jekyll-cache ./_site ./tmp super-linter.log dictionary.dic

--- a/index.md
+++ b/index.md
@@ -47,7 +47,7 @@ Some patterns include both a data center and one or more edge clusters. The diag
 
  3. Import/join the cluster to the hub/data center. Instructions for importing the cluster can be found [here]. You're done.
 
-When the cluster is imported, ACM on the datacenter will deploy an ACM agent and and agent-addon pod into the edge cluster. Once installed and running ACM will then deploy OpenShift GitOps onto the cluster. Then OpenShift GitOps will deploy whatever applications are required for that cluster based on a label.
+When the cluster is imported, ACM on the datacenter will deploy an ACM agent and agent-addon pod into the edge cluster. Once installed and running ACM will then deploy OpenShift GitOps onto the cluster. Then OpenShift GitOps will deploy whatever applications are required for that cluster based on a label.
 
 ## OpenShift GitOps (a.k.a ArgoCD)
 

--- a/multicloud-gitops/index.md
+++ b/multicloud-gitops/index.md
@@ -46,7 +46,7 @@ The pattern is derived from work done by the [Red Hat Portfolio Architecture tea
 
 ## Architecture
 
-At a high level this requires a management hub, for DevOps and GitOps, and and infrastructure that extends to more than one managed clusters running on private or public clouds.
+At a high level this requires a management hub, for DevOps and GitOps, and infrastructure that extends to more than one managed clusters running on private or public clouds.
 
 [![Multi-Cloud Architecture](/images/multicloud-gitops/hybrid-multicloud-management-gitops-hl-arch.png)](/images/multicloud-gitops/hybrid-multicloud-management-gitops-hl-arch.png)
 


### PR DESCRIPTION
- Add clean target to remove build artifacts
- Fix double 'and and' as reported in the redhat-edge-computing/docs repo
