### PR TITLE
Add local Gemfile and switch to using bundle exec

### DIFF
--- a/.github/workflows/htmlproof.yml
+++ b/.github/workflows/htmlproof.yml
@@ -16,15 +16,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-
       - run: |
-          {
-            echo "source 'https://rubygems.org'"
-            echo "gem 'jekyll'"
-            echo "gem 'bundler'"
-            echo "gem 'jekyll-paginate'"
-            echo "gem 'just-the-docs'"
-            echo "gem 'github-pages'"
-            echo "gem 'html-proofer'"
-          } > Gemfile
           bundle config path vendor/bundle
           bundle install --jobs 4 --retry 3
       - run: bundle exec jekyll build

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gem "github-pages", group: :jekyll_plugins
+gem "html-proofer", "~> 3.9"


### PR DESCRIPTION
This way we are explicit in the rubygem requirements we currently have
htmlproofer is pinned to 3.9 because the action we use does not work
with the newly released 4.0.x

We also switch to bundle exec in order to be closer to what gh-pages
does. Also rely on the Gemfile in the htmlproof action now
