### PR TITLE
List dependencies as step 1 for multicloud-gitops

### DIFF
--- a/multicloud-gitops/getting-started.md
+++ b/multicloud-gitops/getting-started.md
@@ -34,6 +34,17 @@ service](https://console.redhat.com/openshift/create).
 
 # How to deploy
 
+1. Install the installation tooling dependencies.  You will need:
+
+    * `make` - the well-known software build tool
+    * `sh` - a POSIX-compatible shell
+    * `sed` - the "stream editor", commonly used in shell scripting
+    * `oc` - the OpenShift client
+    * `jq` - The swiss army knife for JSON
+    * `git` - The well known version control utility
+    * `ansible` - The well-known automation tool
+    * The `kubernetes.core` collection for ansible
+
 1. Fork the [multicloud-gitops](https://github.com/hybrid-cloud-patterns/multicloud-gitops) repo on GitHub.  It is necessary to fork because your fork will be updated as part of the GitOps and DevOps processes.
 
 1. Clone the forked copy of this repository.

--- a/multicloud-gitops/getting-started.md
+++ b/multicloud-gitops/getting-started.md
@@ -40,7 +40,6 @@ service](https://console.redhat.com/openshift/create).
     * `sh` - a POSIX-compatible shell
     * `sed` - the "stream editor", commonly used in shell scripting
     * `oc` - the OpenShift client
-    * `jq` - The swiss army knife for JSON
     * `git` - The well known version control utility
     * `ansible` - The well-known automation tool
     * The `kubernetes.core` collection for ansible


### PR DESCRIPTION
I tried to run the multicluster-gitops pattern on my machine today. The initial run failed because I didn't have the `ansible-playbook` command available. I was browsing other patterns and noticed the list on the Multicluster DevSecOps page. Adding it here so others can immediately see what tools are required.

(Not 100% that list is right for this pattern but it seems close)