### PR TITLE
Multicloud GitOps: Cluster must have dynamic persistent storage

### DIFF
--- a/devsecops/getting-started.md
+++ b/devsecops/getting-started.md
@@ -19,7 +19,7 @@ nav_order: 1
 
 # Prerequisites
 
-1. An OpenShift cluster ( Go to [the OpenShift console](https://console.redhat.com/openshift/create)). See also [sizing your cluster](../../multicloud-gitops/cluster-sizing).
+1. An OpenShift cluster (Go to [the OpenShift console](https://console.redhat.com/openshift/create)). Cluster must have a dynamic StorageClass to provision PersistentVolumes. See also [sizing your cluster](../../multicloud-gitops/cluster-sizing).
 1. A second OpenShift cluster for production (optional but desirable)
 1. A third OpenShift cluster for secure CI pipelines (optional but desirable)
 1. A GitHub account (and a token for it with repositories permissions, to read from and write to your forks)


### PR DESCRIPTION
Tried this pattern today on a cluster without persistent storage. Vault hung in a *Pending* state waiting for a PV to be created. This adds the requirement for anyone else who comes along.