### PR TITLE
Rename bobbycar to Connected Vehicle Architecture

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -59,6 +59,8 @@ clustername
 clustersecretstore
 cncf
 cnv
+cockroachdb
+coffeeshop
 colocated
 compliancetype
 config
@@ -248,6 +250,7 @@ mcollective
 mhjacks
 mhjacks's
 mib
+microservices
 middleware
 militaries
 millicore
@@ -323,6 +326,7 @@ publickey
 pv
 qe
 quickstart
+quarkus
 rabbitmq
 rdma
 readme

--- a/community.md
+++ b/community.md
@@ -30,11 +30,11 @@ A pattern for Kong Gateway Control Plane and Data Plane demo
 
 [Repo](https://github.com/hybrid-cloud-patterns/kong-gateway)
 
-### Bobby Car
+### Connected Vehicle Architecture
 
 A distributed cloud-native application that implements key aspects of a modern IoT architecture.
 
-[Repo](https://github.com/mbaldessari/bobbycar)
+[Repo](https://github.com/hybrid-cloud-patterns/connected-vehicle-architecture)
 
 ### Quarkus Coffee Shop
 


### PR DESCRIPTION
- Rename bobbycar to Connected Vehicle Architecture and use the new repository
- add some words to .wordlist.txt
