### PR TITLE
Fix selinux issues in lintwordlist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ htmlproof:
 		$(JEKYLL_CONTAINER) exec ruby /usr/local/bin/proof-html.rb
 
 lintwordlist:
+	@cp --preserve=all .wordlist.txt /tmp/.wordlist.txt
 	@sort .wordlist.txt | tr '[:upper:]' '[:lower:]' | uniq > /tmp/.wordlist.txt
 	@mv -v /tmp/.wordlist.txt .wordlist.txt
 


### PR DESCRIPTION
As reported by Martin the following can happen on F37:

    $ make lintwordlist
    $ ls -Z .wordlist.txt
    unconfined_u:object_r:user_tmp_t:s0 .wordlist.txt

This then prevents 'make spellcheck' to run. Fix this by precopying the
file in tmp while preserving its original selinux attributes. Tested and
the error is now reproduced anymore
