### PR TITLE
Adding CSS for the adoc files

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,10 +9,11 @@ params:
 security:
   exec:
     allow: ["^dart-sass-embedded$", "^go$", "^npx$", "^postcss$", "^asciidoctor$"]
+    osEnv: (?i)^(GEM_PATH)$
 
 markup:
   asciidocExt:
-    attributes: {allow-uri-read}
+    attributes: {allow-uri-read, source-highlighter: rouge, icons: font, sectanchors}
     safeMode: unsafe
   tableOfContents:
     startLevel: 1

--- a/content/contribute/contribute-to-docs.adoc
+++ b/content/contribute/contribute-to-docs.adoc
@@ -7,7 +7,7 @@ weight: 10
 
 :toc:
 
-Use the Contributor's guide to learn about ways to contribute to the Hybrid Cloud Patterns, to understand the prerequisites and toolchain required for contribution, and to follow some basic documentation style and structure guidelines.
+//Use the Contributor's guide to learn about ways to contribute to the Hybrid Cloud Patterns, to understand the prerequisites and toolchain required for contribution, and to follow some basic documentation style and structure guidelines.
 
 include::modules/contributing.adoc[leveloffset=+1]
 include::modules/tools_and_setup.adoc[leveloffset=+1]

--- a/modules/doc_guidelines.adoc
+++ b/modules/doc_guidelines.adoc
@@ -12,7 +12,7 @@ When authoring content, follow these style guides:
 +
 NOTE: When asked for an IBMid, Red Hat associates can use their Red Hat e-mail.
 * link:https://redhat-documentation.github.io/modular-docs/#writing-mod-docs[Modular documentation reference guide]
-** link:https://github.com/redhat-documentation/modular-docs/tree/main/modular-docs-manual/files[Modular documentation templates]
+* link:https://github.com/redhat-documentation/modular-docs/tree/main/modular-docs-manual/files[Modular documentation templates]
 
 == Modular documentation terms
 
@@ -64,6 +64,7 @@ Use lowercase. For directory with a multiple-word name, use lowercase separated 
 
 == Language and grammar
 Consider the following guidelines:
+
 * Use present tense.
 * Use active voice.
 * Use second person perspective (you).
@@ -112,10 +113,10 @@ Every assembly file should contain the following metadata at the top, with no li
 :_content-type: ASSEMBLY                                        <1>
 [id="<unique-heading-for-assembly>"]                            <2>
 = Assembly title                                                <3>
-include::_common-docs/common-attributes.adoc[]                   <4>
+include::_common-docs/common-attributes.adoc[]                  <4>
 :context: <unique-context-for-assembly>                         <5>
                                                                 <6>
-:toc:                                                         <7>
+:toc:                                                           <7>
 ----
 
 <1> The content type for the file. For assemblies, always use `:_content-type: ASSEMBLY`. Place this attribute before the anchor ID or, if present, the conditional that contains the anchor ID.
@@ -212,7 +213,3 @@ To enable syntax highlighting for a programming language, use `[source]` tags us
 * `[source,go]`
 
 * `[source,javascript]`
-
-
-
-

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -13,11 +13,6 @@
     margin-bottom: 10px;
 }
 
-pre {
-    white-space: pre-wrap; 
-    padding: 10px;
-}
-
 .btn,
 #goog-wm-sb {
  display:inline-block;
@@ -261,4 +256,488 @@ pre {
 .btn .icon+.hidden,
 #goog-wm-sb .icon+.hidden {
  margin-left:-0.5em
+}
+
+/*TITLES*/
+
+/*for now until theres just 1 h1 per page. Then change to 4xl*/
+h1 {
+    --pf-c-content--h1--FontSize: var(--pf-global--FontSize--3xl);
+}
+
+h2 {
+    --pf-c-content--h2--FontSize: var(--pf-global--FontSize--3xl);
+}
+
+h3 {
+    --pf-c-content--h3--FontSize: var(--pf-global--FontSize--2xl);
+}
+
+/* We need this one because patternfly sets this to 0, which
+/* creates a bunched-up effect that we don't want for the docs */
+
+.pf-c-content h1:first-child,
+.pf-c-content h2:first-child,
+.pf-c-content h3:first-child,
+.pf-c-content h4:first-child,
+.pf-c-content h5:first-child,
+.pf-c-content h6:first-child {
+    margin-top: revert;
+  }
+
+/*CODE BLOCKS */
+
+code {
+  font-family: var(--pf-global--FontFamily--monospace);
+}
+
+pre {
+    white-space: pre-wrap;
+    font-family: var(--pf-global--FontFamily--monospace);
+    font-size: 0.9rem;
+    background-color: #f0f0f0;
+    padding: var(--pf-global--spacer--md);
+    margin-bottom: var(--pf-global--spacer--md);
+    margin-top:  var(--pf-global--spacer--md);
+  }
+
+/* literals */
+
+p > code,
+td > code {
+    font-family:  var(--pf-global--FontFamily--monospace);
+    background-color: #f0f0f0;
+    font-size:0.9rem;
+}
+
+/*Adds type of content to listingblock*/
+
+.listingblock >.content {
+    position:relative
+}
+
+.listingblock code[data-lang]::before {
+    content:attr(data-lang);
+    position:absolute;
+    font-size:.75em;
+    top:.425rem;
+    right:.5rem;
+    line-height:1;
+    text-transform:uppercase;
+    color:inherit;
+    opacity:.5;
+}
+
+
+/*FOOTER*/
+
+.footer-dark {
+    background: var(--pf-global--BackgroundColor--dark-300) !important;
+}
+
+#footer img {
+    margin-left: var(--pf-global--spacer--xl) !important;
+}
+
+.site-copyright {
+    font-size: 0.8rem;
+    color: white;
+    margin-left:var(--pf-global--spacer--md) !important
+}
+
+.footer-dark a:first-of-type {
+    padding-left: 0;
+}
+
+.footer-dark a {
+    padding-right: var(--pf-global--spacer--sm);
+    padding-left: var(--pf-global--spacer--sm);
+    border-right: var(--pf-global--BorderWidth--sm) solid #f0f0f0;
+    font-weight: 300;
+    font-size: 0.8rem;
+    color: #f0f0f0;
+    text-decoration: underline;
+}
+
+.footer-dark a:last-of-type {
+    padding-right: 0;
+    border: none;
+  }
+
+/* This makes the main section to expand even if there's no content inside, so that the footer 
+/* remains on the bottom of the page */
+
+.pf-c-page__main-section {
+    flex: 1;
+}
+
+  /* STICKY NAV ON THE LEFT */
+
+.sticky {
+    width: 280px;
+    max-height: calc(100vh - 76px);
+    overflow-y: auto;
+    /* Hide TOC scrollbar IE, Edge & Firefox */
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+    order: 1;
+    padding: 0 var(--pf-global--spacer--lg) var(--pf-global--spacer--lg) var(--pf-global--spacer--2xl);
+    flex-grow: 1;
+    background: none;
+    margin: 0;
+    position: sticky;
+    top: 40px;
+}
+
+nav.ul.li.a {
+   font-size: 0.8rem;
+}
+
+/* LISTS */
+ol,
+ul {
+    margin-top: var(--pf-c-list--nested--MarginTop) !important;
+    margin-left: var(--pf-c-list--nested--MarginLeft);
+}
+
+ul.pf-c-list {
+    list-style: var(--pf-c-list--ul--ListStyle);
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
+
+/* CALLOUTS with fontawesome*/
+
+.colist > table td {
+     padding-top:5px;
+    padding-bottom:5px;
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+.conum[data-value] {
+    display: inline-block;
+    color: #f0f0f0 !important;
+    background-color: #394b54;
+    border-radius: 100px;
+    text-align: center;
+    width: 20px;
+    height: 20px;
+    font-size: .75rem;
+    line-height: 20px;
+    font-family: "Open Sans", "Sans", sans-serif;
+    font-style: normal;
+    text-indent: -1px;
+}
+
+.conum[data-value] * {
+    color: #f0f0f0 !important;
+}
+
+.conum[data-value]+b {
+    display: none;
+}
+
+.conum[data-value]:after {
+    content: attr(data-value);
+}
+
+pre .conum[data-value] {
+    text-shadow: 0 0;
+    position: relative;
+    top: -2px;
+}
+
+b.conum * {
+    color: inherit !important;
+}
+
+.conum:not([data-value]):empty {
+    display: none;
+}
+
+/* ADMONITONS with fontawesome */
+
+.admonitionblock>table {
+    border: 0;
+    background: none;
+    width: 100%;
+    table-layout: fixed;
+}
+
+.admonitionblock > table td.icon {
+    vertical-align: top;
+    text-align: center;
+    width: 80px;
+}
+
+.admonitionblock > table td.content {
+    padding-right:10px;
+    line-height: 1.8;
+}
+
+
+.admonitionblock.note {
+    background: #4e9fde15;
+    border-left: solid #4e9fde;
+}
+
+.admonitionblock td.icon .icon-note::before {
+    content: "\f05a";
+    color: #4E9FDD;
+}
+.admonitionblock.important {
+    background: #ee210015;
+    border-left: solid #ee2100;
+}
+.admonitionblock td.icon .icon-important:before {
+    content: "\f06a";
+    color: #e00;
+}
+
+.admonitionblock.warning {
+    background: #ec7a0915;
+    border-left: solid #ec7a09;
+}
+
+.admonitionblock td.icon .icon-warning:before {
+    content: "\f071";
+    color: #ec7a08;
+}
+
+.admonitionblock td.icon .icon-caution:before {
+    content: "\f06d";
+    color: #ec7a08;
+}
+
+.admonitionblock.caution {
+    background: #ec7a0915;
+    border-left: solid #ec7a09;
+}
+
+.admonitionblock.tip {
+    background: #32859615;
+    border-left: solid #328596;
+}
+
+.admonitionblock td.icon .icon-tip:before {
+    content: "\f0eb";
+    color: #2C8596;
+}
+.admonitionblock>table td.icon img {
+    max-width: none;
+}
+
+.admonitionblock>table td.icon .title {
+    font-weight: 300;
+    text-transform: uppercase;
+}
+
+.admonitionblock.note td.content:before {
+    content: "NOTE\a";
+    white-space: pre;
+    color: #404040;
+    font-weight: bold;
+}
+
+.admonitionblock.important td.content:before {
+    content: "IMPORTANT\a";
+    white-space: pre;
+    color: #404040;
+    font-weight: bold;
+}
+
+.admonitionblock.warning td.content:before {
+    content: "WARNING\a";
+    white-space: pre;
+    color: #404040;
+    font-weight: bold;
+}
+
+.admonitionblock.tip td.content:before {
+    content: "TIP\a";
+    white-space: pre;
+    color: #404040;
+    font-weight: bold;
+}
+
+.admonitionblock.caution td.content:before {
+    content: "CAUTION\a";
+    white-space: pre;
+    color: #404040;
+    font-weight: bold;
+}
+.admonitionblock td.icon [class^="fa icon-"] {
+    font-size: 2.5em;
+    cursor: default;
+    padding-top: .125em;
+}
+
+.fa {
+    font-weight:400;
+    line-height:1;
+    font-weight:400;
+    font-style:normal;
+    font-display:block;
+}
+
+
+/* Rouge default highlights*/
+
+.highlight .hll { background-color: #ffffcc }
+.highlight .c { color: #408080; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { color: #008000; font-weight: bold } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .ch { color: #408080; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
+.highlight .cpf { color: #408080; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #408080; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #408080; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #008000 } /* Keyword.Pseudo */
+.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #B00040 } /* Keyword.Type */
+.highlight .m { color: #666666 } /* Literal.Number */
+.highlight .s { color: #BA2121 } /* Literal.String */
+.highlight .na { color: #7D9029 } /* Name.Attribute */
+.highlight .nb { color: #008000 } /* Name.Builtin */
+.highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.highlight .no { color: #880000 } /* Name.Constant */
+.highlight .nd { color: #AA22FF } /* Name.Decorator */
+.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #0000FF } /* Name.Function */
+.highlight .nl { color: #A0A000 } /* Name.Label */
+.highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #19177C } /* Name.Variable */
+.highlight .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #666666 } /* Literal.Number.Bin */
+.highlight .mf { color: #666666 } /* Literal.Number.Float */
+.highlight .mh { color: #666666 } /* Literal.Number.Hex */
+.highlight .mi { color: #666666 } /* Literal.Number.Integer */
+.highlight .mo { color: #666666 } /* Literal.Number.Oct */
+.highlight .sa { color: #BA2121 } /* Literal.String.Affix */
+.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
+.highlight .sc { color: #BA2121 } /* Literal.String.Char */
+.highlight .dl { color: #BA2121 } /* Literal.String.Delimiter */
+.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
+.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.highlight .sx { color: #008000 } /* Literal.String.Other */
+.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
+.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
+.highlight .ss { color: #19177C } /* Literal.String.Symbol */
+.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #0000FF } /* Name.Function.Magic */
+.highlight .vc { color: #19177C } /* Name.Variable.Class */
+.highlight .vg { color: #19177C } /* Name.Variable.Global */
+.highlight .vi { color: #19177C } /* Name.Variable.Instance */
+.highlight .vm { color: #19177C } /* Name.Variable.Magic */
+.highlight .il { color: #666666 } /* Literal.Number.Integer.Long */
+
+/*  This is for the normal paragraphs
+// that don't get properly styled with other classes */
+div.paragraph {
+  margin-bottom: 10px;
+  margin-top: 10px;
+}
+
+/* TABLES */
+
+table.tableblock tr > :first-child {
+    padding-left: 1rem;
+}
+
+table.tableblock tbody > tr > * {
+    overflow-wrap: break-word;
+    vertical-align: baseline;
+}
+
+table.tableblock thead {
+    font-size: var(--pf-global--FontSize--sm);
+    vertical-align: bottom;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+    max-width: none;
+}
+
+table.tableblock tr > * {
+    display: table-cell;
+    position: relative;
+    width: auto;
+    min-width: 0;
+    max-width: none;
+    padding: 24px;
+    overflow: visible;
+    text-overflow: clip;
+    word-break: normal;
+    white-space: normal;
+  }
+
+/* border*/
+
+table.tableblock tr:not(.pf-c-table__expandable-row) {
+    border-bottom: 1px solid #d7d7d7;
+}
+
+/*striped*/
+
+table.tableblock tbody tr:nth-child(odd) {
+    background: #f0f0f0;
+}
+
+/* TITLE ANCHORS */
+
+h1:hover .anchor,
+h2:hover .anchor,
+h3:hover .anchor,
+h4:hover .anchor,
+h5:hover .anchor,
+h6:hover .anchor {
+    color: #06c;
+    visibility: visible;
+}
+
+h1 .anchor,
+h2 .anchor,
+h3 .anchor,
+h4 .anchor,
+h5 .anchor,
+h6 .anchor {
+ text-decoration:none;
+ width:1.75ex;
+ margin-left:-1.5ex;
+ visibility:hidden;
+ font-size:.8em;
+ font-weight:400;
+ padding-top:.05em;
+ display: inline-block;
+}
+h1 .anchor::before,
+h2 .anchor::before,
+h3 .anchor::before,
+h4 .anchor::before,
+h5 .anchor::before,
+h6 .anchor::before {
+ content:"\00a7";
 }


### PR DESCRIPTION
I've added CSS to the custom.css file  to make the adoc files look OK.  


- Added asciidoc configuration to hugo:  use rouge, use icons for callouts/admon, add anchors to titles
- Also allowed hugo to use the $GEM_PATH env variable if needed. Without this asciidoctor didn't work fine locally for me, but I can take it out if needed. 
- Added CSS for tables, admonitions, headers, callouts, rouge highlighting, etc, etc.
- Corrected some style issues on some of the adoc files. 
- Commented the intro of the assembly.

Note: Some of the CSS is still using Patternfly variables. I was not sure if we wanted them or not.  I'd like to discuss this on our meeting.

Note 2:  The colour scheme isn't exactly the same that we have on markdown (eg, the code blocks aren't black) but I suspect that is OK since we're converting those files.

Note 3:  We need to add the rouge gem to the build machines, and remove asciidoctor config from the git pipeline.

Note 4:  I'll make another PR for the footer and the sticky navigation, though the CSS is already in this change. We should get clarity about what needs to be on the footer (terms and conditions, etc, legal...) 
