### PR TITLE
Add --no-header-footer when invoking asciidoctor

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Build
         run: |
-          alias asciidoctor="asciidoctor --attribute=experimental=true --attribute=icons=font"
+          alias asciidoctor="asciidoctor --no-header-footer --attribute=experimental=true --attribute=icons=font"
           hugo --minify
 
       - name: Deploy


### PR DESCRIPTION
See https://blog.arkey.fr/2020/04/23/tackling-hugo-integration-of-asciidoctor/
this seems to fix the silly footer issues observed in
https://hybrid-cloud-patterns.io/patterns/ansible-edge-gitops/getting-started/
