### PR TITLE
Drop the asciidoctor overrides

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,7 +29,6 @@ jobs:
 
       - name: Build
         run: |
-          alias asciidoctor="asciidoctor --no-header-footer --attribute=experimental=true --attribute=icons=font"
           hugo --minify
 
       - name: Deploy


### PR DESCRIPTION
These are not needed any longer because everything is done via
config.yaml markup+asciidocExt
