### PR TITLE
Updates for the Contribution guide

### DIFF
--- a/modules/contributing.adoc
+++ b/modules/contributing.adoc
@@ -9,7 +9,7 @@
 
 There are a few different ways you can contribute to Hybrid Cloud Patterns documentation:
 
-* Email the Hybrid Cloud Patterns team at `hybrid-cloud-patterns@googlegroups.com`.
+* Email the Hybrid Cloud Patterns team at mailto:hybrid-cloud-patterns@googlegroups.com[hybrid-cloud-patterns@googlegroups.com].
 * Create a link:https://github.com/hybrid-cloud-patterns/docs/issues[GitHub] or link:https://issues.redhat.com/projects/MBP/issues[Jira issue] .
 //to-do: Add link to the contribution workflow when we have a proper one. You might need to create a new file
 * Submit a pull request (PR). To create a PR, create a local clone of your own fork of the link:https://github.com/hybrid-cloud-patterns/docs[Hybrid Cloud Patterns docs repository], make your changes, and submit a PR. This option is best if you have substantial changes.
@@ -29,11 +29,14 @@ When you submit a PR, the https://github.com/orgs/hybrid-cloud-patterns/teams/do
 │   └── blog
 |   └── contribute
 |   └── learn
-|   |  └── multicloud-gitops
-|   |  | └──multicloud-gitops-assembly.adoc
-|   |  └── medical-diagnosis
-|   |    └── medical-diagnosis-assembly.adoc
 |   └── patterns
+|       └── multicloud-gitops
+|       |   └──_index.adoc
+|       |   └──mcg-getting-started.adoc
+|       |
+|       └── medical-diagnosis
+|           └──_index.adoc
+|           └── medical-diagnosis-assembly.adoc
 ├── layouts
 │   └── _default
 |   └── blog
@@ -41,6 +44,7 @@ When you submit a PR, the https://github.com/orgs/hybrid-cloud-patterns/teams/do
 │   └── multicloud-gitops-logical-architecture.adoc
 │   └── multicloud-gitops-physical-architecture.adoc
 ├── static
+|   └── images
 ├── themes/patternfly
 ├── config.yaml
 └── README.adoc

--- a/modules/tools-and-setup.adoc
+++ b/modules/tools-and-setup.adoc
@@ -33,12 +33,14 @@ to clone the forked repository.
 .  Clone the forked repository onto your workstation with the following
 command, replacing _<user_name>_ with your actual GitHub username.
 +
+[source,terminal]
 ----
 $ git clone git@github.com:<user_name>/docs.git
 ----
 
 . Change into the directory for the local repository you just cloned.
 +
+[source,terminal]
 ----
 $ cd docs
 ----
@@ -46,6 +48,7 @@ $ cd docs
 . Add an upstream pointer back to the Hybrid Cloud Patterns's remote repository, in this
 case _docs_.
 +
+[source,terminal]
 ----
 $ git remote add upstream git@github.com:hybrid-cloud-patterns/docs.git
 ----
@@ -65,7 +68,7 @@ The following are minimum requirements:
 * A web browser (Mozilla Firefox, Google Chrome, or Safari)
 * https://docs.asciidoctor.org/asciidoctor/latest/tooling/#web-browser-add-ons-preview-only[Web browser add-ons (preview only)]
 * An editor that can strip trailing whitespace
-* An https://docs.asciidoctor.org/asciidoctor/latest/install/[installer]
+* An https://docs.asciidoctor.org/asciidoctor/latest/install/[Asciidoctor installer]
 
 === Preview the documentation using a container image
 
@@ -75,7 +78,7 @@ You can use the container image to build the Hybrid Cloud Patterns documentation
 
 [source,terminal]
 ----
-$ make server
+$ make serve
 ----
 
 .Verification


### PR DESCRIPTION
This PR fixes a couple of issues in the Contribution guide, namely:

- Typo in make serve command
- Adds `mailto` macro for the email
- Adds the appropriate `source` code blocks 
- Updates the repo structure per recent changes

