### PR TITLE
TELCODOCS-1202: Changing the blog landing page to look like the other pages

### DIFF
--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,5 +1,14 @@
 {{ define "main" }}
-<main class="pf-c-page__main">
+<div class="pf-c-page__sidebar" id="sidebar">
+  <div class="pf-c-page__sidebar-body">
+    <div class="pf-l-flex filter-title-div">
+      <span class="pf-c-title pf-m-md filter-title pf-l-flex__item pf-m-grow">Filter by</span>
+    </div>
+      {{ partial "tags-blog.html" . }}
+  </div>
+</div>
+
+<main class="pf-c-page__main" id="maincontent">
   <section class="pf-c-page__main-section">
     <div class="pf-l-grid__item pf-m-9-col">
       <div class="pf-u-text-align-center">
@@ -10,24 +19,17 @@
         <div class="page-abstract">
           {{ .Content }}
         </div>
-      </div>
-    </div>
-    <div class="pf-l-grid pf-m-gutter">
-      <div class="pf-l-grid__item pf-m-10-col">
-        <div class="pf-c-content" >
-          {{ $section := where $.Paginator.Pages "Section" "blog"}}
-          {{ range $section }}
-            <div >
-              {{ .Render "summary" }}
-            </div>
-          {{ end }}
-          {{ partial "paginator.html" . }}
         </div>
       </div>
-      <div class="pf-l-grid__item pf-m-2-col">
-        {{ partial "tags-blog.html" . }}
+      <div class="pf-c-content" >
+        {{ $section := where $.Paginator.Pages "Section" "blog"}}
+        {{ range $section }}
+          <div >
+            {{ .Render "summary" }}
+          </div>
+        {{ end }}
+        {{ partial "paginator.html" . }}
       </div>
-    </div>
   </section>
   {{ partial "footer.html" . }}
 </main>

--- a/layouts/blog/summary.html
+++ b/layouts/blog/summary.html
@@ -9,7 +9,7 @@
     <p>by {{ .Params.author }}</p>
     {{ end }}
     <p>{{ .Date | time.Format ":date_long" }}</p>
-    <p>{{ .Summary }} <a href="{{ .RelPermalink }}">Read more...</a></p>
+    <p>{{ .Summary }} </p>
     {{ range .Params.blog_tags }}
       <span class="pf-c-label pf-grey">
         <span class="pf-c-label__content">{{ . }}</span>

--- a/layouts/blog_tags/list.html
+++ b/layouts/blog_tags/list.html
@@ -1,34 +1,40 @@
 {{ define "main" }}
+<div class="pf-c-page__sidebar">
+  <div class="pf-c-page__sidebar-body">
+    <div class="pf-l-flex filter-title-div">
+      <span class="pf-c-title pf-m-md filter-title pf-l-flex__item pf-m-grow">Filter by</span>
+      <span class="pf-l-flex__item reset-title">
+        <a href="/blog/">Reset filter</a></span>
+    </div>
+      {{ partial "tags-blog.html" . }}
+  </div>
+</div>
 <main class="pf-c-page__main">
   <section class="pf-c-page__main-section">
-    <div class="pf-u-text-align-center">
-      <div class="pf-c-content" style="--pf-c-content--FontSize: 1.25rem;">
-        <h1>
-          Posts tagged with "{{- .Title -}}"
+    <div class="pf-l-grid__item pf-m-9-col">
+      <div class="pf-u-text-align-center">
+        <div class="pf-c-content" style="--pf-c-content--FontSize: 1rem;">
+          <h1 class="pf-c-title pf-m-4xl">
+            Blog
         </h1>
-        {{ .Content }}
-      </div>
-    </section>
-    <section class="pf-c-page__main-section">
-    <div class="pf-l-grid pf-m-gutter">
-
-      <div class="pf-l-grid__item pf-m-10-col">
-        <div class="pf-c-content" >
-          <div>
-            {{ $section := where $.Paginator.Pages "Section" "blog"}}
-            {{ range $section }}
-              <div >
-                {{ .Render "summary" }}
-              </div>
-            {{ end }}
-            {{ partial "paginator.html" . }}
-          </div>
+        <p>
+          Posts tagged with "{{- .Title -}}"
+        </p>
+        <div class="page-abstract">
+          {{ .Content }}
+        </div>
         </div>
       </div>
-      <div class="pf-l-grid__item pf-m-2-col">
-        {{ partial "tags-blog.html" . }}
+      <div class="pf-c-content" >
+        {{ $section := where $.Paginator.Pages "Section" "blog"}}
+        {{ range $section }}
+          <div >
+            {{ .Render "summary" }}
+          </div>
+        {{ end }}
+        {{ partial "paginator.html" . }}
       </div>
-    </div>
   </section>
+  {{ partial "footer.html" . }}
 </main>
 {{ end }}

--- a/layouts/partials/tags-blog.html
+++ b/layouts/partials/tags-blog.html
@@ -1,17 +1,27 @@
-<div class="pf-c-panel" style="margin-bottom: 1em">
-  <div class="pf-c-panel__header">Blog Tags</div>
-  <hr class="pf-c-divider" />
-  <div class="pf-c-panel__main">
-    <div class="pf-c-panel__main-body">
-    <ul class="pf-c-list pf-m-plain">
-      {{ range $name, $taxonomy := .Site.Taxonomies.blog_tags }}
-       <li>
-         <a class="pf-c-label pf-m-grey" href="{{ "/blog_tags/" | relLangURL }}{{ $name | urlize }}">
-           {{- $name -}}
-         </a>
-       </li>
-      {{ end }}
-    </ul>
+{{ $current := .RelPermalink }}
+{{ $path := "/blog_tags/" }}
+
+<div class="pf-c-select pf-m-expanded">
+  <div class="pf-c-select__menu">
+  <div class="pf-c-panel">
+    <div class="pf-c-panel__main">
+      <div class="pf-c-panel__main-body">
+      <ul class="pf-c-list pf-m-plain">
+        {{ range $name, $taxonomy := .Site.Taxonomies.blog_tags }}
+        <li>
+          {{ $fullpath := $name | printf "%s%s" $path | printf "%s/" }}
+          <!-- This concatenates the path with the tag. Proper golang won't do it -->
+          <a class="pf-c-label pf-m-grey {{ if eq $current $fullpath }}pf-m-blue{{ end }}" href="{{ "/blog_tags/" | relLangURL }}{{ $name | urlize }}">
+            {{- $name -}}
+          </a>
+        </li>
+        {{ end }}
+      </ul>
+      </div>
     </div>
   </div>
+  </div>
 </div>
+
+
+


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/TELCODOCS-1202

- Changes the blog templates so that they look like the other pages. 
- Decided not to go with checkboxes and keep the tags instead since what we have doesn't let you filter by multiple tags. I can change this if you rather have the checkboxes, but it didn't seem to make much sense to have a checkbox if you could only check one at a time.
- The current tag/pill shows in a light blue 
-  Added a "reset filter" link to go back to the blog landing page.
- Removed the "read more" link from the blog tiles.

![image](https://github.com/hybrid-cloud-patterns/docs/assets/94384267/037764e6-9f72-4798-8068-66a33a1c7fe8)
