### PR TITLE
Adding archetype templates to docs site

### DIFF
--- a/archetypes/blog.adoc
+++ b/archetypes/blog.adoc
@@ -1,0 +1,11 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+summary: Provide a short summary of the blog post
+author: Author
+blog_tags:
+- blog tag 1
+- blog tag 2
+---
+
+// Write your blog post here

--- a/archetypes/contribute.adoc
+++ b/archetypes/contribute.adoc
@@ -1,0 +1,9 @@
+---
+menu: contribute
+title: "{{ replace .Name "-" " " | title }}"
+weight: 10
+---
+
+// Add your content here. If you are using modular content, use the include:: directive to add asciidoc modules from the /modules directory.
+// For example:
+// include::modules/my-module.adoc[leveloffset=+1]

--- a/archetypes/default.adoc
+++ b/archetypes/default.adoc
@@ -4,3 +4,4 @@ date: {{ .Date }}
 draft: true
 ---
 
+// Add your content here

--- a/archetypes/learn.adoc
+++ b/archetypes/learn.adoc
@@ -1,0 +1,9 @@
+---
+menu: learn
+title: "{{ replace .Name "-" " " | title }}"
+weight: 10
+---
+
+// Add your content here. If you are using modular content, use the include:: directive to add asciidoc modules from the /modules directory.
+// For example:
+// include::modules/my-module.adoc[leveloffset=+1]

--- a/archetypes/pattern/_index.adoc
+++ b/archetypes/pattern/_index.adoc
@@ -1,0 +1,35 @@
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: {{ .Date }}
+summary:
+products:
+- Product 1
+- Product 2
+- etc
+industries:
+- Industry 1
+- Industry 2
+- etc
+links:
+  install:
+  arch:
+  help: https://groups.google.com/g/hybrid-cloud-patterns
+  bugs:
+# The following parameters are only used for validated patterns. Do not uncomment them unless your pattern is validated.
+# validated:
+# pattern_logo:
+# ci:
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+
+// Use the include:: directive to add asciidoc modules
+// from the /modules directory. For example:
+// include::modules/my-module.adoc[leveloffset=+1]
+
+== Next steps
+
+*
+*

--- a/archetypes/pattern/additional-pages.adoc.template
+++ b/archetypes/pattern/additional-pages.adoc.template
@@ -1,0 +1,18 @@
+// Create a copy of this file and use it as a template for any additional pages
+---
+title: Title
+weight: 10
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+
+// Use the include:: directive to add asciidoc modules
+// from the /modules directory. For example:
+// include::modules/my-module.adoc[leveloffset=+1]
+
+== Next steps
+
+*
+*

--- a/archetypes/pattern/cluster-sizing.adoc
+++ b/archetypes/pattern/cluster-sizing.adoc
@@ -1,0 +1,17 @@
+---
+title: Cluster sizing
+weight: 20
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+
+// Use the include:: directive to add asciidoc modules
+// from the /modules directory. For example:
+// include::modules/my-module.adoc[leveloffset=+1]
+
+== Next steps
+
+*
+*

--- a/archetypes/pattern/getting-started.adoc
+++ b/archetypes/pattern/getting-started.adoc
@@ -1,0 +1,17 @@
+---
+title: Getting started
+weight: 10
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+
+// Use the include:: directive to add asciidoc modules
+// from the /modules directory. For example:
+// include::modules/my-module.adoc[leveloffset=+1]
+
+== Next steps
+
+*
+*

--- a/archetypes/pattern/ideas-for-customization.adoc
+++ b/archetypes/pattern/ideas-for-customization.adoc
@@ -1,0 +1,17 @@
+---
+title: Ideas for customization
+weight: 30
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+
+// Use the include:: directive to add asciidoc modules 
+// from the /modules directory. For example:
+// include::modules/my-module.adoc[leveloffset=+1]
+
+== Next steps
+
+*
+*

--- a/archetypes/pattern/troubleshooting.adoc
+++ b/archetypes/pattern/troubleshooting.adoc
@@ -1,0 +1,17 @@
+---
+title: Ideas for customization
+weight: 30
+---
+
+:toc:
+:imagesdir: /images
+:_content-type: ASSEMBLY
+
+// Use the include:: directive to add asciidoc modules
+// from the /modules directory. For example:
+// include::modules/my-module.adoc[leveloffset=+1]
+
+== Next steps
+
+*
+*


### PR DESCRIPTION
This commit provides a set of templates that users can easily use to create new pages on our website.

For example, run the following command to add a new Learn page:

~~~
$ hugo new learn/my-new-page.adoc
~~~

And Hugo will use the `archetypes/learn.adoc` template as a basis.

To add a new pattern, run the following command:

~~~
$ hugo new --kind pattern patterns/my-new-pattern
~~~

And Hugo will use the templates from `archetypes/pattern` to create a new pattern in the `Patterns` section.

For more information, see https://gohugo.io/content-management/archetypes/