### PR TITLE
Adding links for validated and community patterns

### DIFF
--- a/layouts/partials/menu-patterns-browser.html
+++ b/layouts/partials/menu-patterns-browser.html
@@ -23,10 +23,16 @@
                 <label class="pf-c-check pf-c-select__menu-item" for="type:validated">
                   <input class="pf-c-check__input" type="checkbox" onclick="filterSelection(this.id)" id="type:validated" name="validated"/>
                   <span class="pf-c-check__label">Validated by Red Hat</span>
+                  <span class="pf-c-check__description">
+                    <a href="/learn/validated/">What are validated patterns?</a>
+                  </span>
                 </label>
                 <label class="pf-c-check pf-c-select__menu-item" for="type:community">
                   <input class="pf-c-check__input" type="checkbox" onclick="filterSelection(this.id)" id="type:community" name="community"/>
                   <span class="pf-c-check__label">Community pattern</span>
+                  <span class="pf-c-check__description">
+                    <a href="/learn/community/">What are community patterns?</a>
+                  </span>
                 </label>
               </fieldset>
           </div>


### PR DESCRIPTION
When a user navigates to the pattern browser
(https://hybrid-cloud-patterns.io/patterns/) and clicks "Pattern Type", they now see links to documentation in the description for the checkbox items. This helps users who are wondering what the difference is between a validated pattern and a community pattern.

![image](https://github.com/hybrid-cloud-patterns/docs/assets/1260665/29a00ae9-d35c-4df2-becb-f3ecf2f9533e)
